### PR TITLE
Python 37 support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,7 +7,7 @@ environment:
 
   - PYTHON: "C:\\Python27-x64"
   - PYTHON: "C:\\Python36-x64"
-#  - PYTHON: "C:\\Python37-x64"
+  - PYTHON: "C:\\Python37-x64"
 
 
 build: off

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ python:
   - "2.7"
   - "3.6"
 # Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs
-#matrix:
-#  include:
-#    - python: 3.7
-#      dist: xenial
-#      sudo: true
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
 install:
   # Install the code requirements
   - make init

--- a/aws_lambda_builders/validate.py
+++ b/aws_lambda_builders/validate.py
@@ -32,7 +32,8 @@ _RUNTIME_VERSION_RESOLVER = {
 class RuntimeValidator(object):
     SUPPORTED_RUNTIMES = [
         "python2.7",
-        "python3.6"
+        "python3.6",
+        "python3.7",
     ]
 
     @classmethod

--- a/aws_lambda_builders/workflows/python_pip/actions.py
+++ b/aws_lambda_builders/workflows/python_pip/actions.py
@@ -17,15 +17,14 @@ class PythonPipBuildAction(BaseAction):
         self.manifest_path = manifest_path
         self.scratch_dir = scratch_dir
         self.runtime = runtime
-        self.package_builder = PythonPipDependencyBuilder()
+        self.package_builder = PythonPipDependencyBuilder(runtime=runtime)
 
     def execute(self):
         try:
             self.package_builder.build_dependencies(
                 self.artifacts_dir,
                 self.manifest_path,
-                self.scratch_dir,
-                self.runtime,
+                self.scratch_dir
             )
         except PackagerError as ex:
             raise ActionFailedError(str(ex))

--- a/aws_lambda_builders/workflows/python_pip/compat.py
+++ b/aws_lambda_builders/workflows/python_pip/compat.py
@@ -1,6 +1,4 @@
 import os
-import six
-import sys
 
 
 def pip_import_string():
@@ -102,10 +100,3 @@ else:
     pip_no_compile_c_env_vars = {
         'CC': '/var/false'
     }
-
-
-if six.PY3:
-    # cp37m or cp36m
-    lambda_abi = 'cp{}{}m'.format(sys.version_info.major, sys.version_info.minor)
-else:
-    lambda_abi = 'cp27mu'

--- a/aws_lambda_builders/workflows/python_pip/compat.py
+++ b/aws_lambda_builders/workflows/python_pip/compat.py
@@ -1,5 +1,6 @@
 import os
 import six
+import sys
 
 
 def pip_import_string():
@@ -104,6 +105,7 @@ else:
 
 
 if six.PY3:
-    lambda_abi = 'cp36m'
+    # cp37m or cp36m
+    lambda_abi = 'cp{}{}m'.format(sys.version_info.major, sys.version_info.minor)
 else:
     lambda_abi = 'cp27mu'

--- a/aws_lambda_builders/workflows/python_pip/packager.py
+++ b/aws_lambda_builders/workflows/python_pip/packager.py
@@ -326,7 +326,7 @@ class DependencyBuilder(object):
             # Deploying python 3 function which means we need cp36m abi
             # We can also accept abi3 which is the CPython 3 Stable ABI and
             # will work on any version of python 3.
-            return abi == 'cp36m' or abi == 'abi3'
+            return abi == lambda_abi or abi == 'abi3'
         elif prefix_version == 'cp2':
             # Deploying to python 2 function which means we need cp27mu abi
             return abi == 'cp27mu'

--- a/tests/functional/workflows/python_pip/test_packager.py
+++ b/tests/functional/workflows/python_pip/test_packager.py
@@ -1,3 +1,4 @@
+import sys
 import os
 import zipfile
 import tarfile
@@ -16,7 +17,7 @@ from aws_lambda_builders.workflows.python_pip.packager import SubprocessPip
 from aws_lambda_builders.workflows.python_pip.packager import SDistMetadataFetcher
 from aws_lambda_builders.workflows.python_pip.packager import \
     InvalidSourceDistributionNameError
-from aws_lambda_builders.workflows.python_pip.compat import lambda_abi
+from aws_lambda_builders.workflows.python_pip.packager import get_lambda_abi
 from aws_lambda_builders.workflows.python_pip.compat import pip_no_compile_c_env_vars
 from aws_lambda_builders.workflows.python_pip.compat import pip_no_compile_c_shim
 from aws_lambda_builders.workflows.python_pip.utils import OSUtils
@@ -214,7 +215,8 @@ class TestDependencyBuilder(object):
     def _make_appdir_and_dependency_builder(self, reqs, tmpdir, runner):
         appdir = str(_create_app_structure(tmpdir))
         self._write_requirements_txt(reqs, appdir)
-        builder = DependencyBuilder(OSUtils(), runner)
+        runtime = "python{}.{}".format(sys.version_info.major, sys.version_info.minor)
+        builder = DependencyBuilder(OSUtils(), runtime, runner)
         return appdir, builder
 
     def test_can_build_local_dir_as_whl(self, tmpdir, pip_runner, osutils):
@@ -644,7 +646,7 @@ class TestDependencyBuilder(object):
             expected_args=[
                 '--only-binary=:all:', '--no-deps', '--platform',
                 'manylinux1_x86_64', '--implementation', 'cp',
-                '--abi', lambda_abi, '--dest', mock.ANY,
+                '--abi', get_lambda_abi(builder.runtime), '--dest', mock.ANY,
                 'bar==1.2'
             ],
             packages=[
@@ -677,7 +679,7 @@ class TestDependencyBuilder(object):
             expected_args=[
                 '--only-binary=:all:', '--no-deps', '--platform',
                 'manylinux1_x86_64', '--implementation', 'cp',
-                '--abi', lambda_abi, '--dest', mock.ANY,
+                '--abi', get_lambda_abi(builder.runtime), '--dest', mock.ANY,
                 'sqlalchemy==1.1.18'
             ],
             packages=[
@@ -839,7 +841,7 @@ class TestDependencyBuilder(object):
             expected_args=[
                 '--only-binary=:all:', '--no-deps', '--platform',
                 'manylinux1_x86_64', '--implementation', 'cp',
-                '--abi', lambda_abi, '--dest', mock.ANY,
+                '--abi', get_lambda_abi(builder.runtime), '--dest', mock.ANY,
                 'foo==1.2'
             ],
             packages=[

--- a/tests/functional/workflows/python_pip/test_packager.py
+++ b/tests/functional/workflows/python_pip/test_packager.py
@@ -215,8 +215,7 @@ class TestDependencyBuilder(object):
     def _make_appdir_and_dependency_builder(self, reqs, tmpdir, runner):
         appdir = str(_create_app_structure(tmpdir))
         self._write_requirements_txt(reqs, appdir)
-        runtime = "python{}.{}".format(sys.version_info.major, sys.version_info.minor)
-        builder = DependencyBuilder(OSUtils(), runtime, runner)
+        builder = DependencyBuilder(OSUtils(), "python3.6", runner)
         return appdir, builder
 
     def test_can_build_local_dir_as_whl(self, tmpdir, pip_runner, osutils):

--- a/tests/integration/workflows/python_pip/test_python_pip.py
+++ b/tests/integration/workflows/python_pip/test_python_pip.py
@@ -47,11 +47,9 @@ class TestPythonPipWorkflow(TestCase):
         self.assertEquals(expected_files, output_files)
 
     def test_runtime_validate_python_project_fail_open_unsupported_runtime(self):
-        self.builder.build(self.source_dir, self.artifacts_dir, self.scratch_dir, self.manifest_path_valid,
-                           runtime="python2.8")
-        expected_files = self.test_data_files.union({"numpy", "numpy-1.15.4.data", "numpy-1.15.4.dist-info"})
-        output_files = set(os.listdir(self.artifacts_dir))
-        self.assertEquals(expected_files, output_files)
+        with self.assertRaises(WorkflowFailedError) as ctx:
+            self.builder.build(self.source_dir, self.artifacts_dir, self.scratch_dir, self.manifest_path_valid,
+                               runtime="python2.8")
 
     def test_must_fail_to_resolve_dependencies(self):
 

--- a/tests/integration/workflows/python_pip/test_python_pip.py
+++ b/tests/integration/workflows/python_pip/test_python_pip.py
@@ -47,7 +47,7 @@ class TestPythonPipWorkflow(TestCase):
         self.assertEquals(expected_files, output_files)
 
     def test_runtime_validate_python_project_fail_open_unsupported_runtime(self):
-        with self.assertRaises(WorkflowFailedError) as ctx:
+        with self.assertRaises(WorkflowFailedError):
             self.builder.build(self.source_dir, self.artifacts_dir, self.scratch_dir, self.manifest_path_valid,
                                runtime="python2.8")
 

--- a/tests/unit/workflows/python_pip/test_actions.py
+++ b/tests/unit/workflows/python_pip/test_actions.py
@@ -20,8 +20,7 @@ class TestPythonPipBuildAction(TestCase):
 
         builder_instance.build_dependencies.assert_called_with("artifacts",
                                                                "scratch_dir",
-                                                               "manifest",
-                                                               "runtime")
+                                                               "manifest")
 
     @patch("aws_lambda_builders.workflows.python_pip.actions.PythonPipDependencyBuilder")
     def test_must_raise_exception_on_failure(self, PythonPipDependencyBuilderMock):

--- a/tests/unit/workflows/python_pip/test_packager.py
+++ b/tests/unit/workflows/python_pip/test_packager.py
@@ -1,4 +1,3 @@
-import sys
 from collections import namedtuple
 
 import mock

--- a/tests/unit/workflows/python_pip/test_packager.py
+++ b/tests/unit/workflows/python_pip/test_packager.py
@@ -12,6 +12,7 @@ from aws_lambda_builders.workflows.python_pip.packager import PythonPipDependenc
 from aws_lambda_builders.workflows.python_pip.packager import Package
 from aws_lambda_builders.workflows.python_pip.packager import PipRunner
 from aws_lambda_builders.workflows.python_pip.packager import SubprocessPip
+from aws_lambda_builders.workflows.python_pip.packager import get_lambda_abi
 from aws_lambda_builders.workflows.python_pip.packager \
     import InvalidSourceDistributionNameError
 from aws_lambda_builders.workflows.python_pip.packager import NoSuchPackageError
@@ -85,6 +86,17 @@ class FakePopenOSUtils(OSUtils):
         return self._processes.pop()
 
 
+class TestGetLambdaAbi(object):
+    def test_get_lambda_abi_python27(self):
+        assert "cp27mu" == get_lambda_abi("python2.7")
+
+    def test_get_lambda_abi_python36(self):
+        assert "cp36m" == get_lambda_abi("python3.6")
+
+    def test_get_lambda_abi_python37(self):
+        assert "cp37m" == get_lambda_abi("python3.7")
+
+
 class TestPythonPipDependencyBuilder(object):
     def test_can_call_dependency_builder(self, osutils):
         mock_dep_builder = mock.Mock(spec=DependencyBuilder)
@@ -92,10 +104,11 @@ class TestPythonPipDependencyBuilder(object):
         builder = PythonPipDependencyBuilder(
             osutils=osutils_mock,
             dependency_builder=mock_dep_builder,
+            runtime="runtime"
         )
         builder.build_dependencies(
             'artifacts/path/', 'scratch_dir/path/',
-            'path/to/requirements.txt', 'python3.6'
+            'path/to/requirements.txt'
         )
         mock_dep_builder.build_site_packages.assert_called_once_with(
             'path/to/requirements.txt', 'artifacts/path/', 'scratch_dir/path/')
@@ -218,14 +231,10 @@ class TestPipRunner(object):
         # for getting lambda compatible wheels.
         pip, runner = pip_factory()
         packages = ['foo', 'bar', 'baz']
-        runner.download_manylinux_wheels(packages, 'directory')
-        if sys.version_info[0] == 2:
-            abi = 'cp27mu'
-        else:
-            abi = 'cp36m'
+        runner.download_manylinux_wheels(packages, 'directory', "abi")
         expected_prefix = ['download', '--only-binary=:all:', '--no-deps',
                            '--platform', 'manylinux1_x86_64',
-                           '--implementation', 'cp', '--abi', abi,
+                           '--implementation', 'cp', '--abi', "abi",
                            '--dest', 'directory']
         for i, package in enumerate(packages):
             assert pip.calls[i].args == expected_prefix + [package]
@@ -234,7 +243,7 @@ class TestPipRunner(object):
 
     def test_download_wheels_no_wheels(self, pip_factory):
         pip, runner = pip_factory()
-        runner.download_manylinux_wheels([], 'directory')
+        runner.download_manylinux_wheels([], 'directory', "abi")
         assert len(pip.calls) == 0
 
     def test_raise_no_such_package_error(self, pip_factory):


### PR DESCRIPTION
*Description of changes:*
Lambda supports Python 3.7. Adding support for building Py37 functions in the builder.

Tested this change locally by running integration tests in Python 3.7

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
