### PR TITLE
Adding wheel dependency for python_pip packager

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,5 @@
 include LICENSE
-include requirements/base.txt
-include requirements/dev.txt
+include requirements/*
 recursive-include aws_lambda_builders/workflows *
 prune tests
 

--- a/requirements/python_pip.txt
+++ b/requirements/python_pip.txt
@@ -1,0 +1,5 @@
+
+# Following packages are required by `python_pip` workflow to run.
+# TODO: Consider moving this dependency directly into the `python_pip` workflow module
+setuptools
+wheel

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
             '{}=aws_lambda_builders.__main__:main'.format(cmd_name)
         ]
     },
-    install_requires=read_requirements('base.txt'),
+    install_requires=read_requirements('base.txt') + read_requirements("python_pip.txt"),
     extras_require={
         'dev': read_requirements('dev.txt')
     },


### PR DESCRIPTION
*Issue #, if available:*
#31 and #29 

*Description of changes:*
`python_pip` packager depends on setuptools and wheel to be available in environment. Ideally we would install these requirements into the target Python version we build, but to help the 80% of the case where they had pip installed this library, I am including the dependency directly here. 

This also helps when you install the library inside a Docker container that uses a Python version that doesn't come with wheel.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
