### PR TITLE
fix: astroid version compatible to be compatible with pylint1.7

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,7 +2,9 @@ coverage==4.3.4
 flake8==3.3.0
 tox==2.2.1
 pytest-cov==2.4.0
-pylint==1.7.2
+# astroid > 2.0.4 is not compatible with pylint1.7
+astroid>=1.5.8,<2.1.0
+pylint~=2.2
 
 # Test requirements
 pytest==3.0.7

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@ tox==2.2.1
 pytest-cov==2.4.0
 # astroid > 2.0.4 is not compatible with pylint1.7
 astroid>=1.5.8,<2.1.0
-pylint~=2.2
+pylint==1.7.2
 
 # Test requirements
 pytest==3.0.7


### PR DESCRIPTION
*Issue #, if available:*
Travis started failing for Py3.6 and up. Fix similar to https://github.com/awslabs/aws-sam-cli/pull/795

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
