### PR TITLE
Feature: npm prebuild and postbuild

### DIFF
--- a/aws_lambda_builders/workflows/nodejs_npm/DESIGN.md
+++ b/aws_lambda_builders/workflows/nodejs_npm/DESIGN.md
@@ -78,7 +78,11 @@ Lambda environment.
 The general algorithm for preparing a node package for use on AWS Lambda
 is as follows.
 
-#### Step 1: Prepare a clean copy of the project source files
+#### Step 1: Execute prebuild scripts
+
+For situations where precompilation is required, such as typescript, users can define `sam:prebuild` npm script which will be executed in the source directory before packaging. (Note: development dependencies may be available at this point if the developer installs them in the source folder)
+
+#### Step 2: Prepare a clean copy of the project source files
 
 Execute `npm pack` to perform project-specific packaging using the supplied
 `package.json` manifest, which will automatically exclude temporary files, 
@@ -90,7 +94,7 @@ directory.  Note that the archive will actually contain a `package`
 subdirectory containing the files, so it's not enough to just directly unpack
 files. 
 
-#### Step 2: Rewrite local dependencies
+#### Step 3: Rewrite local dependencies
 
 _(out of scope for the current version)_
 
@@ -115,7 +119,7 @@ to the package.json manifest. In this case, the packager will need to remove
 `package-lock.json` so that dependency rewrites take effect. 
 _(out of scope for the current version)_
 
-#### Step 3: Install dependencies
+#### Step 4: Install dependencies
 
 The packager should then run `npm install` to download an expand all dependencies to
 the local `node_modules` subdirectory. This has to be executed in the directory with
@@ -133,5 +137,7 @@ _(out of scope for the current version)_
 
 To fully support dependencies that download or compile binaries for a target platform, this step
 needs to be executed inside a Docker image compatible with AWS Lambda. 
-_(out of scope for the current version)_
 
+#### Step 5: Execute postbuild scripts
+
+For situations where postcompilation actions are required, such as removing postinstall artifacts or downloading binaries required by npm dependencies, users can define `sam:postbuild` npm script which will be executed in the artifacts directory after installing dependencies. (Note: only production dependencies are available at this point)

--- a/aws_lambda_builders/workflows/nodejs_npm/actions.py
+++ b/aws_lambda_builders/workflows/nodejs_npm/actions.py
@@ -172,5 +172,6 @@ class NodejsNpmScriptAction(BaseAction):
         except NpmExecutionError as ex:
             raise ActionFailedError(str(ex))
 
-        except json.decoder.JSONDecodeError as ex:
+        except ValueError as ex:
+            # Python 2.7 doesn't have JSONDecoderError
             raise ActionFailedError("{} is not valid json: {}".format(self.manifest_path, str(ex)))

--- a/aws_lambda_builders/workflows/nodejs_npm/utils.py
+++ b/aws_lambda_builders/workflows/nodejs_npm/utils.py
@@ -6,7 +6,7 @@ import os
 import platform
 import tarfile
 import subprocess
-
+import io
 
 class OSUtils(object):
 
@@ -38,3 +38,7 @@ class OSUtils(object):
 
     def is_windows(self):
         return platform.system().lower() == 'windows'
+
+    def get_text_contents(self, filename, encoding='utf-8'):
+        with io.open(filename, 'r', encoding=encoding) as f:
+            return f.read()

--- a/aws_lambda_builders/workflows/nodejs_npm/workflow.py
+++ b/aws_lambda_builders/workflows/nodejs_npm/workflow.py
@@ -4,7 +4,7 @@ NodeJS NPM Workflow
 
 from aws_lambda_builders.workflow import BaseWorkflow, Capability
 from aws_lambda_builders.actions import CopySourceAction
-from .actions import NodejsNpmPackAction, NodejsNpmInstallAction
+from .actions import NodejsNpmPackAction, NodejsNpmInstallAction, NodejsNpmScriptAction
 from .utils import OSUtils
 from .npm import SubprocessNpm
 
@@ -55,8 +55,19 @@ class NodejsNpmWorkflow(BaseWorkflow):
 
         npm_install = NodejsNpmInstallAction(artifacts_dir,
                                              subprocess_npm=subprocess_npm)
+
         self.actions = [
+            NodejsNpmScriptAction(source_dir,
+                                  manifest_path,
+                                  'sam:prebuild',
+                                  subprocess_npm=subprocess_npm,
+                                  osutils=osutils),
             npm_pack,
             CopySourceAction(tar_package_dir, artifacts_dir, excludes=self.EXCLUDED_FILES),
             npm_install,
+            NodejsNpmScriptAction(artifacts_dir,
+                                  manifest_path,
+                                  'sam:postbuild',
+                                  subprocess_npm=subprocess_npm,
+                                  osutils=osutils),
         ]

--- a/tests/functional/workflows/nodejs_npm/test_data/test.txt
+++ b/tests/functional/workflows/nodejs_npm/test_data/test.txt
@@ -1,0 +1,1 @@
+Sample text file

--- a/tests/functional/workflows/nodejs_npm/test_utils.py
+++ b/tests/functional/workflows/nodejs_npm/test_utils.py
@@ -75,3 +75,11 @@ class TestOSUtils(TestCase):
         self.assertEqual(p.returncode, 0)
 
         self.assertEqual(out.decode('utf8').strip(), os.path.abspath(testdata_dir))
+
+    def test_get_text_contents_reads_text_file(self):
+
+        test_txt = os.path.join(os.path.dirname(__file__), "test_data", "test.txt")
+
+        result = self.osutils.get_text_contents(test_txt)
+
+        self.assertEqual(result, "Sample text file")

--- a/tests/integration/workflows/nodejs_npm/testdata/postbuild-broken/package.json
+++ b/tests/integration/workflows/nodejs_npm/testdata/postbuild-broken/package.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0.0",
+  "name": "postbuild",
+  "private": true,
+  "scripts": {
+    "sam:postbuild": "node script.js"
+  }
+}

--- a/tests/integration/workflows/nodejs_npm/testdata/postbuild-broken/script.js
+++ b/tests/integration/workflows/nodejs_npm/testdata/postbuild-broken/script.js
@@ -1,0 +1,1 @@
+throw new Error('Some JS error')

--- a/tests/integration/workflows/nodejs_npm/testdata/postbuild/.gitignore
+++ b/tests/integration/workflows/nodejs_npm/testdata/postbuild/.gitignore
@@ -1,0 +1,1 @@
+prebuild.*

--- a/tests/integration/workflows/nodejs_npm/testdata/postbuild/package.json
+++ b/tests/integration/workflows/nodejs_npm/testdata/postbuild/package.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0.0",
+  "name": "postbuild",
+  "private": true,
+  "scripts": {
+    "sam:postbuild": "node script.js"
+  },
+  "files": ["*.js"]
+}

--- a/tests/integration/workflows/nodejs_npm/testdata/postbuild/script.js
+++ b/tests/integration/workflows/nodejs_npm/testdata/postbuild/script.js
@@ -1,0 +1,6 @@
+'use strct'
+
+const fs = require('fs')
+const path = require('path')
+
+fs.writeFileSync(path.join(__dirname, 'postbuild.txt'), 'Postbuild', 'utf8')

--- a/tests/integration/workflows/nodejs_npm/testdata/prebuild-broken/package.json
+++ b/tests/integration/workflows/nodejs_npm/testdata/prebuild-broken/package.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0.0",
+  "name": "prebuild",
+  "private": true,
+  "scripts": {
+    "sam:prebuild": "node script.js"
+  }
+}

--- a/tests/integration/workflows/nodejs_npm/testdata/prebuild-broken/prebuild.txt
+++ b/tests/integration/workflows/nodejs_npm/testdata/prebuild-broken/prebuild.txt
@@ -1,0 +1,1 @@
+Prebuild

--- a/tests/integration/workflows/nodejs_npm/testdata/prebuild-broken/script.js
+++ b/tests/integration/workflows/nodejs_npm/testdata/prebuild-broken/script.js
@@ -1,0 +1,1 @@
+throw new Error('Some error')

--- a/tests/integration/workflows/nodejs_npm/testdata/prebuild/.gitignore
+++ b/tests/integration/workflows/nodejs_npm/testdata/prebuild/.gitignore
@@ -1,0 +1,1 @@
+prebuild.*

--- a/tests/integration/workflows/nodejs_npm/testdata/prebuild/package.json
+++ b/tests/integration/workflows/nodejs_npm/testdata/prebuild/package.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0.0",
+  "name": "prebuild",
+  "private": true,
+  "scripts": {
+    "sam:prebuild": "node script.js"
+  },
+  "files": ["*.js"]
+}

--- a/tests/integration/workflows/nodejs_npm/testdata/prebuild/script.js
+++ b/tests/integration/workflows/nodejs_npm/testdata/prebuild/script.js
@@ -1,0 +1,7 @@
+'use strct'
+
+const fs = require('fs')
+const path = require('path')
+
+fs.writeFileSync(path.join(__dirname, 'prebuild.txt'), 'Prebuild', 'utf8')
+fs.writeFileSync(path.join(__dirname, 'prebuild.js'), 'Prebuild', 'utf8')

--- a/tests/unit/workflows/nodejs_npm/test_actions.py
+++ b/tests/unit/workflows/nodejs_npm/test_actions.py
@@ -2,7 +2,8 @@ from unittest import TestCase
 from mock import patch
 
 from aws_lambda_builders.actions import ActionFailedError
-from aws_lambda_builders.workflows.nodejs_npm.actions import NodejsNpmPackAction, NodejsNpmInstallAction
+from aws_lambda_builders.workflows.nodejs_npm.actions import \
+    NodejsNpmPackAction, NodejsNpmInstallAction, NodejsNpmScriptAction
 from aws_lambda_builders.workflows.nodejs_npm.npm import NpmExecutionError
 
 
@@ -78,3 +79,118 @@ class TestNodejsNpmInstallAction(TestCase):
             action.execute()
 
         self.assertEqual(raised.exception.args[0], "NPM Failed: boom!")
+
+
+class TestNodejsNpmScriptAction(TestCase):
+
+    @patch("aws_lambda_builders.workflows.nodejs_npm.npm.SubprocessNpm")
+    @patch("aws_lambda_builders.workflows.nodejs_npm.utils.OSUtils")
+    def test_does_not_execute_script_if_no_scripts(self, SubprocessNpmMock, OSUtilMock):
+        osutils = OSUtilMock.return_value
+        subprocess_npm = SubprocessNpmMock.return_value
+
+        action = NodejsNpmScriptAction("workdir",
+                                       "manifest_path",
+                                       "script_name",
+                                       subprocess_npm=subprocess_npm,
+                                       osutils=osutils)
+
+        osutils.get_text_contents.side_effect = ['{"version":"1.0.0"}']
+
+        action.execute()
+
+        subprocess_npm.run.assert_not_called()
+
+    @patch("aws_lambda_builders.workflows.nodejs_npm.npm.SubprocessNpm")
+    @patch("aws_lambda_builders.workflows.nodejs_npm.utils.OSUtils")
+    def test_does_not_execute_script_if_requested_script_not_defined(self, SubprocessNpmMock, OSUtilMock):
+        osutils = OSUtilMock.return_value
+        subprocess_npm = SubprocessNpmMock.return_value
+
+        action = NodejsNpmScriptAction("workdir",
+                                       "manifest_path",
+                                       "script_name",
+                                       subprocess_npm=subprocess_npm,
+                                       osutils=osutils)
+
+        osutils.get_text_contents.side_effect = ['{"version":"1.0.0","scripts":{"not_script_name":"something"}}']
+
+        action.execute()
+
+        subprocess_npm.run.assert_not_called()
+
+    @patch("aws_lambda_builders.workflows.nodejs_npm.npm.SubprocessNpm")
+    @patch("aws_lambda_builders.workflows.nodejs_npm.utils.OSUtils")
+    def test_executes_script_if_requested_script_is_defined(self, SubprocessNpmMock, OSUtilMock):
+        osutils = OSUtilMock.return_value
+        subprocess_npm = SubprocessNpmMock.return_value
+
+        action = NodejsNpmScriptAction("workdir",
+                                       "manifest_path",
+                                       "script_name",
+                                       subprocess_npm=subprocess_npm,
+                                       osutils=osutils)
+
+        osutils.get_text_contents.side_effect = ['{"version":"1.0.0","scripts":{"script_name":"something"}}']
+
+        action.execute()
+
+        subprocess_npm.run.assert_called_with(['run', 'script_name'], cwd='workdir')
+
+    @patch("aws_lambda_builders.workflows.nodejs_npm.npm.SubprocessNpm")
+    @patch("aws_lambda_builders.workflows.nodejs_npm.utils.OSUtils")
+    def test_reads_manifest_path_to_get_json(self, SubprocessNpmMock, OSUtilMock):
+        osutils = OSUtilMock.return_value
+        subprocess_npm = SubprocessNpmMock.return_value
+
+        action = NodejsNpmScriptAction("workdir",
+                                       "manifest_path",
+                                       "script_name",
+                                       subprocess_npm=subprocess_npm,
+                                       osutils=osutils)
+
+        osutils.get_text_contents.side_effect = ['{}']
+
+        action.execute()
+
+        osutils.get_text_contents.assert_called_with('manifest_path')
+
+    @patch("aws_lambda_builders.workflows.nodejs_npm.npm.SubprocessNpm")
+    @patch("aws_lambda_builders.workflows.nodejs_npm.utils.OSUtils")
+    def test_raises_action_failed_when_npm_fails(self, SubprocessNpmMock, OSUtilMock):
+        osutils = OSUtilMock.return_value
+        subprocess_npm = SubprocessNpmMock.return_value
+
+        subprocess_npm.run.side_effect = NpmExecutionError(message="boom!")
+
+        action = NodejsNpmScriptAction("workdir",
+                                       "manifest_path",
+                                       "script_name",
+                                       subprocess_npm=subprocess_npm,
+                                       osutils=osutils)
+
+        osutils.get_text_contents.side_effect = ['{"scripts":{"script_name":"script_name"}}']
+
+        with self.assertRaises(ActionFailedError) as raised:
+            action.execute()
+
+        self.assertEqual(raised.exception.args[0], "NPM Failed: boom!")
+
+    @patch("aws_lambda_builders.workflows.nodejs_npm.npm.SubprocessNpm")
+    @patch("aws_lambda_builders.workflows.nodejs_npm.utils.OSUtils")
+    def test_raises_action_failed_if_manifest_not_json(self, SubprocessNpmMock, OSUtilMock):
+        osutils = OSUtilMock.return_value
+        subprocess_npm = SubprocessNpmMock.return_value
+
+        osutils.get_text_contents.side_effect = ["test=True"]
+
+        action = NodejsNpmScriptAction("workdir",
+                                       "manifest_path",
+                                       "script_name",
+                                       subprocess_npm=subprocess_npm,
+                                       osutils=osutils)
+
+        with self.assertRaises(ActionFailedError) as raised:
+            action.execute()
+
+        self.assertIn("manifest_path is not valid json:", str(raised.exception))

--- a/tests/unit/workflows/nodejs_npm/test_workflow.py
+++ b/tests/unit/workflows/nodejs_npm/test_workflow.py
@@ -2,7 +2,8 @@ from unittest import TestCase
 
 from aws_lambda_builders.actions import CopySourceAction
 from aws_lambda_builders.workflows.nodejs_npm.workflow import NodejsNpmWorkflow
-from aws_lambda_builders.workflows.nodejs_npm.actions import NodejsNpmPackAction, NodejsNpmInstallAction
+from aws_lambda_builders.workflows.nodejs_npm.actions import \
+    NodejsNpmPackAction, NodejsNpmInstallAction, NodejsNpmScriptAction
 
 
 class TestNodejsNpmWorkflow(TestCase):
@@ -16,10 +17,14 @@ class TestNodejsNpmWorkflow(TestCase):
 
         workflow = NodejsNpmWorkflow("source", "artifacts", "scratch_dir", "manifest")
 
-        self.assertEqual(len(workflow.actions), 3)
+        self.assertEqual(len(workflow.actions), 5)
 
-        self.assertIsInstance(workflow.actions[0], NodejsNpmPackAction)
+        self.assertIsInstance(workflow.actions[0], NodejsNpmScriptAction)
 
-        self.assertIsInstance(workflow.actions[1], CopySourceAction)
+        self.assertIsInstance(workflow.actions[1], NodejsNpmPackAction)
 
-        self.assertIsInstance(workflow.actions[2], NodejsNpmInstallAction)
+        self.assertIsInstance(workflow.actions[2], CopySourceAction)
+
+        self.assertIsInstance(workflow.actions[3], NodejsNpmInstallAction)
+
+        self.assertIsInstance(workflow.actions[4], NodejsNpmScriptAction)


### PR DESCRIPTION
*Issue #, if available:*
This implements additional build steps required by: https://github.com/awslabs/aws-sam-cli/issues/858. 

*Description of changes:*
Adding `sam:prebuild` and `sam:postbuild` npm scripts for Node.js projects, that will be executed before and after sam build command.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.