### PR TITLE
Updates bundler in AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,7 +20,8 @@ install:
 - "%PYTHON%\\python.exe -m pip install -r requirements/dev.txt"
 - "%PYTHON%\\python.exe -m pip install -e ."
 - "set PATH=C:\\Ruby25-x64\\bin;%PATH%"
-- "gem install bundler --no-ri --no-rdoc"
+- "gem --version"
+- "gem install bundler -v 1.17.3 --no-ri --no-rdoc"
 - "bundler --version"
 
 test_script:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Pins bundled version on AppVeyor. 

AppVeyor drops out with:
```
ERROR:  Error installing bundler:
	The last version of bundler (>= 0) to support your Ruby & RubyGems was 1.17.3. Try installing it with `gem install bundler -v 1.17.3`
	bundler requires RubyGems version >= 3.0.0. The current RubyGems version is 2.7.8. Try 'gem update --system' to update RubyGems itself.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
