### PR TITLE
GoDep Design doc

### DIFF
--- a/aws_lambda_builders/workflows/go_dep/DESIGN.md
+++ b/aws_lambda_builders/workflows/go_dep/DESIGN.md
@@ -1,0 +1,33 @@
+# Go Dep - Lambda Builder
+
+## Scope
+Building Go projects using the dep tool (https://github.com/golang/dep) is rather simple, if you was to do
+this by hand, you would perform these commands:
+
+    - `dep ensure`
+    - `GOOS=linux GOARCH=amd64 go build -o handler main.go`
+    - `zip -r source.zip`
+
+The scope of `sam build` would be to create a macro for these commands to ensure that spelling and paths are correct.
+We don't have to care about versioning of the tooling of either Go or dep since Lambda doesn't have to care, and so it becomes
+user preference.
+
+## Implementation
+The go-dep builder runs the above commands with some minor tweaks, the commands ran on behalf of the user are:
+
+    1. dep ensure
+    2. GOOS=linux GOARCH=amd64 go build -o $ARTIFACT_DIR/$HANDLER_NAME $SOURCE_DIR
+
+The main difference being we want to capture the compiled binary to package later, so the binary has the
+output path as the artifact dir set by the caller.
+
+## Challenges
+There are no challenges for go building, most problems have been abstracted away by the Go tooling
+
+## Notes
+Go does native cross-compilation regardless of what's compiling it. Regardless of how the user builds their code it would run on
+AWS Lambda.
+
+### Layers
+This pattern might not work for Layers, plugins for go require an extra compilation flag (`-buildmode=plugin`), this would be something
+to add later on, should SAM CLI support building layers

--- a/aws_lambda_builders/workflows/go_dep/DESIGN.md
+++ b/aws_lambda_builders/workflows/go_dep/DESIGN.md
@@ -8,7 +8,7 @@ this by hand, you would perform these commands:
     - `GOOS=linux GOARCH=amd64 go build -o handler main.go`
     - `zip -r source.zip`
 
-The scope of `sam build` would be to create a macro for these commands to ensure that spelling and paths are correct.
+The scope of the Go dep builder is to create a macro for these commands to ensure that spelling and paths are correct.
 We don't have to care about versioning of the tooling of either Go or dep since Lambda doesn't have to care, and so it becomes
 user preference.
 


### PR DESCRIPTION

*Description of changes:*
Creates a design doc for go-dep builder, it was omitted from the original PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
