### PR TITLE
Fix local package installation

### DIFF
--- a/aws_lambda_builders/workflows/python_pip/packager.py
+++ b/aws_lambda_builders/workflows/python_pip/packager.py
@@ -631,8 +631,8 @@ class PipRunner(object):
                 raise NoSuchPackageError(str(package_name))
             raise PackageDownloadError(error)
         stdout = out.decode()
-        match = re.search(self._LINK_IS_DIR_PATTERN, stdout)
-        if match:
+        matches = re.finditer(self._LINK_IS_DIR_PATTERN, stdout)
+        for match in matches:
             wheel_package_path = str(match.group(1))
             # Looks odd we do not check on the error status of building the
             # wheel here. We can assume this is a valid package path since

--- a/tests/unit/workflows/python_pip/test_packager.py
+++ b/tests/unit/workflows/python_pip/test_packager.py
@@ -248,6 +248,36 @@ class TestPipRunner(object):
         runner.download_manylinux_wheels([], 'directory', "abi")
         assert len(pip.calls) == 0
 
+    def test_does_find_local_directory(self, pip_factory):
+        pip, runner = pip_factory()
+        pip.add_return((0,
+                        (b"Processing ../local-dir\n"
+                         b"  Link is a directory,"
+                         b" ignoring download_dir"),
+                        b''))
+        runner.download_all_dependencies('requirements.txt', 'directory')
+        assert len(pip.calls) == 2
+        assert pip.calls[1].args == ['wheel', '--no-deps', '--wheel-dir',
+                                     'directory', '../local-dir']
+
+    def test_does_find_multiple_local_directories(self, pip_factory):
+        pip, runner = pip_factory()
+        pip.add_return((0,
+                        (b"Processing ../local-dir-1\n"
+                         b"  Link is a directory,"
+                         b" ignoring download_dir"
+                         b"\nsome pip output...\n"
+                         b"Processing ../local-dir-2\n"
+                         b"  Link is a directory,"
+                         b" ignoring download_dir"),
+                        b''))
+        runner.download_all_dependencies('requirements.txt', 'directory')
+        assert len(pip.calls) == 3
+        assert pip.calls[1].args == ['wheel', '--no-deps', '--wheel-dir',
+                                     'directory', '../local-dir-1']
+        assert pip.calls[2].args == ['wheel', '--no-deps', '--wheel-dir',
+                                     'directory', '../local-dir-2']
+
     def test_raise_no_such_package_error(self, pip_factory):
         pip, runner = pip_factory()
         pip.add_return((1, b'',


### PR DESCRIPTION
When packaging the dependencies only the first local package would be
included in the final bundle. This change adds support for any number
of local directory links to be treated as buildable dependencies. Tests
were also added for the case of 1 or 2 local directory links specified
in the requirements.txt.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
