### PR TITLE
fix: update license key in setup() to expected value by PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     author='Amazon Web Services',
     author_email='aws-sam-developers@amazon.com',
     url='https://github.com/awslabs/aws-lambda-builders',
-    license=read('LICENSE'),
+    license='Apache License 2.0',
     packages=find_packages(exclude=('tests', 'docs')),
     keywords="AWS Lambda Functions Building",
     # Support Python 2.7 and 3.6 or greater


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Previously we were adding the complete license into the `license` key in `setup()`. This cause a corruption of the METADATA file that exist within the packaged `whl` or `tar` file. PyPi uses this file to render the homepage for the project and pip uses this for validation locally (should it install into X python version for example).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
