### PR TITLE
feat: allow path resolver to look at additional paths

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,7 +23,7 @@ install:
 - "%PYTHON%\\python.exe -m pip install -e ."
 - "set PATH=C:\\Ruby25-x64\\bin;%PATH%"
 - "gem --version"
-- "gem install bundler -v 1.17.3 --no-ri --no-rdoc"
+- "gem install bundler -v 1.17.3"
 - "bundler --version"
 - "echo %PATH%"
 

--- a/aws_lambda_builders/__init__.py
+++ b/aws_lambda_builders/__init__.py
@@ -2,4 +2,4 @@
 AWS Lambda Builder Library
 """
 __version__ = '0.0.5'
-RPC_PROTOCOL_VERSION = "0.2"
+RPC_PROTOCOL_VERSION = "0.1"

--- a/aws_lambda_builders/__init__.py
+++ b/aws_lambda_builders/__init__.py
@@ -2,4 +2,4 @@
 AWS Lambda Builder Library
 """
 __version__ = '0.0.5'
-RPC_PROTOCOL_VERSION = "0.1"
+RPC_PROTOCOL_VERSION = "0.2"

--- a/aws_lambda_builders/__main__.py
+++ b/aws_lambda_builders/__main__.py
@@ -54,7 +54,9 @@ def _parse_version(version_string):
     if VERSION_REGEX.match(version_string):
         return float(version_string)
     else:
-        raise ValueError("Protocol Version does not match : {}".format(VERSION_REGEX.pattern))
+        ex = "Protocol Version does not match : {}".format(VERSION_REGEX.pattern)
+        LOG.debug(ex)
+        raise ValueError(ex)
 
 
 def version_compatibility_check(version):

--- a/aws_lambda_builders/__main__.py
+++ b/aws_lambda_builders/__main__.py
@@ -10,10 +10,11 @@ import sys
 import json
 import os
 import logging
+import re
 
 from aws_lambda_builders.builder import LambdaBuilder
 from aws_lambda_builders.exceptions import WorkflowNotFoundError, WorkflowUnknownError, WorkflowFailedError
-
+from aws_lambda_builders import RPC_PROTOCOL_VERSION as lambda_builders_protocol_version
 
 log_level = int(os.environ.get("LAMBDA_BUILDERS_LOG_LEVEL", logging.INFO))
 
@@ -23,6 +24,8 @@ logging.basicConfig(stream=sys.stderr,
                     format='%(message)s')
 
 LOG = logging.getLogger(__name__)
+
+VERSION_REGEX = re.compile("^([0-9])+.([0-9]+)$")
 
 
 def _success_response(request_id, artifacts_dir):
@@ -44,6 +47,22 @@ def _error_response(request_id, http_status_code, message):
             "message": message
         }
     })
+
+
+def _parse_version(version_string):
+
+    if VERSION_REGEX.match(version_string):
+        return float(version_string)
+    else:
+        raise ValueError("Protocol Version does not match : {}".format(VERSION_REGEX.pattern))
+
+
+def version_compatibility_check(version):
+    if _parse_version(lambda_builders_protocol_version) < version:
+        ex = "Incompatible Protocol Version : {}, " \
+             "Current Protocol Version: {}".format(version, lambda_builders_protocol_version)
+        LOG.error(ex)
+        raise ValueError(ex)
 
 
 def _write_response(response, exit_code):
@@ -77,11 +96,20 @@ def main():  # pylint: disable=too-many-statements
         response = _error_response(request_id, -32601, "Method unavailable")
         return _write_response(response, 1)
 
+    try:
+        protocol_version = _parse_version(params.get("__protocol_version"))
+        version_compatibility_check(protocol_version)
+
+    except ValueError:
+        response = _error_response(request_id, 505, "Unsupported Protocol Version")
+        return _write_response(response, 1)
+
     capabilities = params["capability"]
     supported_workflows = params.get("supported_workflows")
 
     exit_code = 0
     response = None
+
     try:
         builder = LambdaBuilder(language=capabilities["language"],
                                 dependency_manager=capabilities["dependency_manager"],
@@ -93,6 +121,7 @@ def main():  # pylint: disable=too-many-statements
                       params["artifacts_dir"],
                       params["scratch_dir"],
                       params["manifest_path"],
+                      executable_search_paths=params['executable_search_paths'],
                       runtime=params["runtime"],
                       optimizations=params["optimizations"],
                       options=params["options"])

--- a/aws_lambda_builders/__main__.py
+++ b/aws_lambda_builders/__main__.py
@@ -60,6 +60,13 @@ def _parse_version(version_string):
 
 
 def version_compatibility_check(version):
+    # The following check is between current protocol version vs version of the protocol
+    # with which aws-lambda-builders is called.
+    # Example:
+    # 0.2 < 0.2 comparison will fail, don't throw a value Error saying incompatible version.
+    # 0.2 < 0.3 comparison will pass, throwing a ValueError
+    # 0.2 < 0.1 comparison will fail, don't throw a value Error saying incompatible version
+
     if _parse_version(lambda_builders_protocol_version) < version:
         ex = "Incompatible Protocol Version : {}, " \
              "Current Protocol Version: {}".format(version, lambda_builders_protocol_version)

--- a/aws_lambda_builders/builder.py
+++ b/aws_lambda_builders/builder.py
@@ -56,7 +56,7 @@ class LambdaBuilder(object):
         LOG.debug("Found workflow '%s' to support capabilities '%s'", self.selected_workflow_cls.NAME, self.capability)
 
     def build(self, source_dir, artifacts_dir, scratch_dir, manifest_path,
-              runtime=None, optimizations=None, options=None):
+              runtime=None, additional_search_paths=None, optimizations=None, options=None):
         """
         Actually build the code by running workflows
 
@@ -82,6 +82,10 @@ class LambdaBuilder(object):
             Optional, name of the AWS Lambda runtime that you are building for. This is sent to the builder for
             informational purposes.
 
+        :type additional_search_paths: list
+        :param additional_search_paths:
+            Additional list of paths to search for executables required by the workflow.
+
         :type optimizations: dict
         :param optimizations:
             Optional dictionary of optimization flags to pass to the build action. **Not supported**.
@@ -100,7 +104,8 @@ class LambdaBuilder(object):
                                               manifest_path,
                                               runtime=runtime,
                                               optimizations=optimizations,
-                                              options=options)
+                                              options=options,
+                                              additional_search_paths=additional_search_paths)
 
         return workflow.run()
 

--- a/aws_lambda_builders/builder.py
+++ b/aws_lambda_builders/builder.py
@@ -56,7 +56,7 @@ class LambdaBuilder(object):
         LOG.debug("Found workflow '%s' to support capabilities '%s'", self.selected_workflow_cls.NAME, self.capability)
 
     def build(self, source_dir, artifacts_dir, scratch_dir, manifest_path,
-              runtime=None, additional_search_paths=None, optimizations=None, options=None):
+              runtime=None, optimizations=None, options=None, executable_search_paths=None):
         """
         Actually build the code by running workflows
 
@@ -82,10 +82,6 @@ class LambdaBuilder(object):
             Optional, name of the AWS Lambda runtime that you are building for. This is sent to the builder for
             informational purposes.
 
-        :type additional_search_paths: list
-        :param additional_search_paths:
-            Additional list of paths to search for executables required by the workflow.
-
         :type optimizations: dict
         :param optimizations:
             Optional dictionary of optimization flags to pass to the build action. **Not supported**.
@@ -93,6 +89,10 @@ class LambdaBuilder(object):
         :type options: dict
         :param options:
             Optional dictionary of options ot pass to build action. **Not supported**.
+
+        :type executable_search_paths: list
+        :param executable_search_paths:
+            Additional list of paths to search for executables required by the workflow.
         """
 
         if not os.path.exists(scratch_dir):
@@ -105,7 +105,7 @@ class LambdaBuilder(object):
                                               runtime=runtime,
                                               optimizations=optimizations,
                                               options=options,
-                                              additional_search_paths=additional_search_paths)
+                                              executable_search_paths=executable_search_paths)
 
         return workflow.run()
 

--- a/aws_lambda_builders/path_resolver.py
+++ b/aws_lambda_builders/path_resolver.py
@@ -7,15 +7,16 @@ from aws_lambda_builders.utils import which
 
 class PathResolver(object):
 
-    def __init__(self, binary, runtime):
+    def __init__(self, binary, runtime, additional_search_paths=None):
         self.binary = binary
         self.runtime = runtime
         self.executables = [self.runtime, self.binary]
+        self.additional_search_paths = additional_search_paths
 
     def _which(self):
         exec_paths = []
         for executable in [executable for executable in self.executables if executable is not None]:
-            paths = which(executable)
+            paths = which(executable, additional_search_paths=self.additional_search_paths)
             exec_paths.extend(paths)
 
         if not exec_paths:

--- a/aws_lambda_builders/path_resolver.py
+++ b/aws_lambda_builders/path_resolver.py
@@ -7,16 +7,16 @@ from aws_lambda_builders.utils import which
 
 class PathResolver(object):
 
-    def __init__(self, binary, runtime, additional_search_paths=None):
+    def __init__(self, binary, runtime, executable_search_paths=None):
         self.binary = binary
         self.runtime = runtime
         self.executables = [self.runtime, self.binary]
-        self.additional_search_paths = additional_search_paths
+        self.executable_search_paths = executable_search_paths
 
     def _which(self):
         exec_paths = []
         for executable in [executable for executable in self.executables if executable is not None]:
-            paths = which(executable, additional_search_paths=self.additional_search_paths)
+            paths = which(executable, executable_search_paths=self.executable_search_paths)
             exec_paths.extend(paths)
 
         if not exec_paths:

--- a/aws_lambda_builders/utils.py
+++ b/aws_lambda_builders/utils.py
@@ -68,14 +68,27 @@ def copytree(source, destination, ignore=None):
 # Copyright 2019 by the Python Software Foundation
 
 
-def which(cmd, mode=os.F_OK | os.X_OK, additional_search_paths=None):  # pragma: no cover
-    """Given a command, mode, and an additional search paths list, return the paths which
+def which(cmd, mode=os.F_OK | os.X_OK, executable_search_paths=None):  # pragma: no cover
+    """Given a command, mode, and executable search paths list, return the paths which
     conforms to the given mode on the PATH with the prepended additional search paths,
     or None if there is no such file.
     `mode` defaults to os.F_OK | os.X_OK. the default search `path` defaults
     to the result of os.environ.get("PATH")
     Note: This function was backported from the Python 3 source code.
+
+    :type cmd: str
+    :param cmd:
+        Executable to be looked up in PATH.
+
+    :type mode: str
+    :param mode:
+        Modes of access for the executable.
+
+    :type executable_search_paths: list
+    :param executable_search_paths:
+        List of paths to look for `cmd` in preference order.
     """
+
     # Check that a given file can be accessed with the correct mode.
     # Additionally check that `file` is not a directory, as on Windows
     # directories pass the os.access check.
@@ -94,11 +107,13 @@ def which(cmd, mode=os.F_OK | os.X_OK, additional_search_paths=None):  # pragma:
 
     path = os.environ.get("PATH", os.defpath)
 
-    if additional_search_paths:
-        for pth in additional_search_paths:
-            path.insert(0, pth)
+    if not path:
+        return None
 
     path = path.split(os.pathsep)
+
+    if executable_search_paths:
+        path = executable_search_paths + path
 
     if sys.platform == "win32":
         # The current directory takes precedence on Windows.

--- a/aws_lambda_builders/utils.py
+++ b/aws_lambda_builders/utils.py
@@ -68,13 +68,12 @@ def copytree(source, destination, ignore=None):
 # Copyright 2019 by the Python Software Foundation
 
 
-def which(cmd, mode=os.F_OK | os.X_OK, path=None):  # pragma: no cover
-    """Given a command, mode, and a PATH string, return the paths which
-    conforms to the given mode on the PATH, or None if there is no such
-    file.
-    `mode` defaults to os.F_OK | os.X_OK. `path` defaults to the result
-    of os.environ.get("PATH"), or can be overridden with a custom search
-    path.
+def which(cmd, mode=os.F_OK | os.X_OK, additional_search_paths=None):  # pragma: no cover
+    """Given a command, mode, and an additional search paths list, return the paths which
+    conforms to the given mode on the PATH with the prepended additional search paths,
+    or None if there is no such file.
+    `mode` defaults to os.F_OK | os.X_OK. the default search `path` defaults
+    to the result of os.environ.get("PATH")
     Note: This function was backported from the Python 3 source code.
     """
     # Check that a given file can be accessed with the correct mode.
@@ -93,10 +92,11 @@ def which(cmd, mode=os.F_OK | os.X_OK, path=None):  # pragma: no cover
 
         return None
 
-    if path is None:
-        path = os.environ.get("PATH", os.defpath)
-    if not path:
-        return None
+    path = os.environ.get("PATH", os.defpath)
+
+    if additional_search_paths:
+        for pth in additional_search_paths:
+            path.insert(0, pth)
 
     path = path.split(os.pathsep)
 

--- a/aws_lambda_builders/workflow.py
+++ b/aws_lambda_builders/workflow.py
@@ -117,6 +117,7 @@ class BaseWorkflow(six.with_metaclass(_WorkflowMetaClass, object)):
                  scratch_dir,
                  manifest_path,
                  runtime=None,
+                 additional_search_paths=None,
                  optimizations=None,
                  options=None):
         """
@@ -145,6 +146,10 @@ class BaseWorkflow(six.with_metaclass(_WorkflowMetaClass, object)):
             Optional, name of the AWS Lambda runtime that you are building for. This is sent to the builder for
             informational purposes.
 
+        :type additional_search_paths: list
+        :param additional_search_paths:
+            Optional, Additional list of paths to search for executables required by the workflow.
+
         :type optimizations: dict
         :param optimizations:
             Optional dictionary of optimization flags to pass to the build action. **Not supported**.
@@ -161,6 +166,7 @@ class BaseWorkflow(six.with_metaclass(_WorkflowMetaClass, object)):
         self.runtime = runtime
         self.optimizations = optimizations
         self.options = options
+        self.additional_search_paths = additional_search_paths
 
         # Actions are registered by the subclasses as they seem fit
         self.actions = []
@@ -181,7 +187,8 @@ class BaseWorkflow(six.with_metaclass(_WorkflowMetaClass, object)):
         """
         Non specialized path resolver that just returns the list of executable for the runtime on the path.
         """
-        return [PathResolver(runtime=self.runtime, binary=self.CAPABILITY.language)]
+        return [PathResolver(runtime=self.runtime, binary=self.CAPABILITY.language,
+                             additional_search_paths=self.additional_search_paths)]
 
     def get_validators(self):
         """

--- a/aws_lambda_builders/workflow.py
+++ b/aws_lambda_builders/workflow.py
@@ -117,7 +117,7 @@ class BaseWorkflow(six.with_metaclass(_WorkflowMetaClass, object)):
                  scratch_dir,
                  manifest_path,
                  runtime=None,
-                 additional_search_paths=None,
+                 executable_search_paths=None,
                  optimizations=None,
                  options=None):
         """
@@ -146,10 +146,6 @@ class BaseWorkflow(six.with_metaclass(_WorkflowMetaClass, object)):
             Optional, name of the AWS Lambda runtime that you are building for. This is sent to the builder for
             informational purposes.
 
-        :type additional_search_paths: list
-        :param additional_search_paths:
-            Optional, Additional list of paths to search for executables required by the workflow.
-
         :type optimizations: dict
         :param optimizations:
             Optional dictionary of optimization flags to pass to the build action. **Not supported**.
@@ -157,6 +153,10 @@ class BaseWorkflow(six.with_metaclass(_WorkflowMetaClass, object)):
         :type options: dict
         :param options:
             Optional dictionary of options ot pass to build action. **Not supported**.
+
+        :type executable_search_paths: list
+        :param executable_search_paths:
+            Optional, Additional list of paths to search for executables required by the workflow.
         """
 
         self.source_dir = source_dir
@@ -166,7 +166,7 @@ class BaseWorkflow(six.with_metaclass(_WorkflowMetaClass, object)):
         self.runtime = runtime
         self.optimizations = optimizations
         self.options = options
-        self.additional_search_paths = additional_search_paths
+        self.executable_search_paths = executable_search_paths
 
         # Actions are registered by the subclasses as they seem fit
         self.actions = []
@@ -188,7 +188,7 @@ class BaseWorkflow(six.with_metaclass(_WorkflowMetaClass, object)):
         Non specialized path resolver that just returns the list of executable for the runtime on the path.
         """
         return [PathResolver(runtime=self.runtime, binary=self.CAPABILITY.language,
-                             additional_search_paths=self.additional_search_paths)]
+                             executable_search_paths=self.executable_search_paths)]
 
     def get_validators(self):
         """

--- a/tests/functional/test_builder.py
+++ b/tests/functional/test_builder.py
@@ -4,6 +4,11 @@ import os
 import shutil
 import tempfile
 
+try:
+    import pathlib
+except ImportError:
+    import pathlib2 as pathlib
+
 from unittest import TestCase
 from aws_lambda_builders.builder import LambdaBuilder
 
@@ -40,12 +45,13 @@ class TestBuilderWithHelloWorkflow(TestCase):
         # Remove the workflows folder from PYTHONPATH
         sys.path.remove(self.TEST_WORKFLOWS_FOLDER)
 
-    def test_run_hello_workflow(self):
+    def test_run_hello_workflow_with_exec_paths(self):
 
         self.hello_builder.build(self.source_dir,
                                  self.artifacts_dir,
                                  self.scratch_dir,
-                                 "/ignored")
+                                 "/ignored",
+                                 executable_search_paths=[str(pathlib.Path(sys.executable).parent)])
 
         self.assertTrue(os.path.exists(self.expected_filename))
         contents = ''

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -65,6 +65,7 @@ class TestCliWithHelloWorkflow(TestCase):
                 "runtime": "ignored",
                 "optimizations": {},
                 "options": {},
+                "additional_paths": []
             }
         })
 

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -50,17 +50,19 @@ class TestCliWithHelloWorkflow(TestCase):
         shutil.rmtree(self.artifacts_dir)
 
     @parameterized.expand([
-        ("request_through_stdin"),
-        ("request_through_argument")
+        ("request_through_stdin", lambda_builders_protocol_version),
+        ("request_through_argument", lambda_builders_protocol_version),
+        ("request_through_stdin", "0.1"),
+        ("request_through_argument", "0.1"),
     ])
-    def test_run_hello_workflow(self, flavor):
+    def test_run_hello_workflow_with_backcompat(self, flavor, protocol_version):
 
         request_json = json.dumps({
             "jsonschema": "2.0",
             "id": 1234,
             "method": "LambdaBuilder.build",
             "params": {
-                "__protocol_version": lambda_builders_protocol_version,
+                "__protocol_version": protocol_version,
                 "capability": {
                     "language": self.language,
                     "dependency_manager": self.dependency_manager,

--- a/tests/functional/test_utils.py
+++ b/tests/functional/test_utils.py
@@ -40,6 +40,7 @@ class TestCopyTree(TestCase):
         self.assertEquals(set(os.listdir(os.path.join(self.dest, "a"))), {"c"})
         self.assertEquals(set(os.listdir(os.path.join(self.dest, "a"))), {"c"})
 
+
 def file(*args):
     path = os.path.join(*args)
     basedir = os.path.dirname(path)

--- a/tests/unit/test_builder.py
+++ b/tests/unit/test_builder.py
@@ -79,10 +79,10 @@ class TesetLambdaBuilder_init(TestCase):
                          runtime=None,
                          optimizations=None,
                          options=None,
-                         additional_paths=None):
+                         executable_search_paths=None):
                 super(MyWorkflow, self).__init__(source_dir, artifacts_dir, scratch_dir, manifest_path,
                                                  runtime=runtime, optimizations=optimizations, options=options,
-                                                 additional_paths=additional_paths)
+                                                 executable_search_paths=executable_search_paths)
 
         # Don't load any other workflows. The above class declaration will automatically load the workflow into registry
         builder = LambdaBuilder(self.lang, self.lang_framework, self.app_framework, supported_workflows=[])
@@ -121,11 +121,11 @@ class TesetLambdaBuilder_build(TestCase):
 
         builder.build("source_dir", "artifacts_dir", "scratch_dir", "manifest_path",
                       runtime="runtime", optimizations="optimizations", options="options",
-                      additional_search_paths="additional_search_paths")
+                      executable_search_paths="executable_search_paths")
 
         workflow_cls.assert_called_with("source_dir", "artifacts_dir", "scratch_dir", "manifest_path",
                                         runtime="runtime", optimizations="optimizations", options="options",
-                                        additional_search_paths="additional_search_paths")
+                                        executable_search_paths="executable_search_paths")
         workflow_instance.run.assert_called_once()
         os_mock.path.exists.assert_called_once_with("scratch_dir")
         if scratch_dir_exists:

--- a/tests/unit/test_builder.py
+++ b/tests/unit/test_builder.py
@@ -78,9 +78,11 @@ class TesetLambdaBuilder_init(TestCase):
                          manifest_path,
                          runtime=None,
                          optimizations=None,
-                         options=None):
+                         options=None,
+                         additional_paths=None):
                 super(MyWorkflow, self).__init__(source_dir, artifacts_dir, scratch_dir, manifest_path,
-                                                 runtime=runtime, optimizations=optimizations, options=options)
+                                                 runtime=runtime, optimizations=optimizations, options=options,
+                                                 additional_paths=additional_paths)
 
         # Don't load any other workflows. The above class declaration will automatically load the workflow into registry
         builder = LambdaBuilder(self.lang, self.lang_framework, self.app_framework, supported_workflows=[])
@@ -118,10 +120,12 @@ class TesetLambdaBuilder_build(TestCase):
         builder = LambdaBuilder(self.lang, self.lang_framework, self.app_framework, supported_workflows=[])
 
         builder.build("source_dir", "artifacts_dir", "scratch_dir", "manifest_path",
-                      runtime="runtime", optimizations="optimizations", options="options")
+                      runtime="runtime", optimizations="optimizations", options="options",
+                      additional_search_paths="additional_search_paths")
 
         workflow_cls.assert_called_with("source_dir", "artifacts_dir", "scratch_dir", "manifest_path",
-                                        runtime="runtime", optimizations="optimizations", options="options")
+                                        runtime="runtime", optimizations="optimizations", options="options",
+                                        additional_search_paths="additional_search_paths")
         workflow_instance.run.assert_called_once()
         os_mock.path.exists.assert_called_once_with("scratch_dir")
         if scratch_dir_exists:

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -1,6 +1,12 @@
-
+import os
+import sys
 from unittest import TestCase
 from mock import Mock, call
+
+try:
+    import pathlib
+except ImportError:
+    import pathlib2 as pathlib
 
 from aws_lambda_builders.binary_path import BinaryPath
 from aws_lambda_builders.validator import RuntimeValidator
@@ -89,7 +95,7 @@ class TestBaseWorkflow_init(TestCase):
     def test_must_initialize_variables(self):
         self.work = self.MyWorkflow("source_dir", "artifacts_dir", "scratch_dir", "manifest_path",
                                     runtime="runtime",
-                                    additional_search_paths=[],
+                                    executable_search_paths=[str(sys.executable)],
                                     optimizations={"a": "b"},
                                     options={"c": "d"})
 
@@ -98,6 +104,7 @@ class TestBaseWorkflow_init(TestCase):
         self.assertEquals(self.work.scratch_dir, "scratch_dir")
         self.assertEquals(self.work.manifest_path, "manifest_path")
         self.assertEquals(self.work.runtime, "runtime")
+        self.assertEquals(self.work.executable_search_paths, [str(sys.executable)])
         self.assertEquals(self.work.optimizations, {"a": "b"})
         self.assertEquals(self.work.options, {"c": "d"})
 
@@ -114,7 +121,7 @@ class TestBaseWorkflow_is_supported(TestCase):
     def setUp(self):
         self.work = self.MyWorkflow("source_dir", "artifacts_dir", "scratch_dir", "manifest_path",
                                     runtime="runtime",
-                                    additional_search_paths=[],
+                                    executable_search_paths=[],
                                     optimizations={"a": "b"},
                                     options={"c": "d"})
 
@@ -152,7 +159,7 @@ class TestBaseWorkflow_run(TestCase):
     def setUp(self):
         self.work = self.MyWorkflow("source_dir", "artifacts_dir", "scratch_dir", "manifest_path",
                                     runtime="runtime",
-                                    additional_search_paths=[],
+                                    executable_search_paths=[],
                                     optimizations={"a": "b"},
                                     options={"c": "d"})
 
@@ -219,6 +226,18 @@ class TestBaseWorkflow_run(TestCase):
 
         self.assertIn("somevalueerror", str(ctx.exception))
 
+    def test_supply_executable_path(self):
+        # Run workflow with supplied executable path to search for executables.
+        action_mock = Mock()
+
+        self.work = self.MyWorkflow("source_dir", "artifacts_dir", "scratch_dir", "manifest_path",
+                                    runtime="runtime",
+                                    executable_search_paths=[str(pathlib.Path(os.getcwd()).parent)],
+                                    optimizations={"a": "b"},
+                                    options={"c": "d"})
+        self.work.actions = [action_mock.action1, action_mock.action2, action_mock.action3]
+        self.work.run()
+
 
 class TestBaseWorkflow_repr(TestCase):
 
@@ -242,7 +261,7 @@ class TestBaseWorkflow_repr(TestCase):
 
         self.work = self.MyWorkflow("source_dir", "artifacts_dir", "scratch_dir", "manifest_path",
                                     runtime="runtime",
-                                    additional_search_paths=[],
+                                    executable_search_paths=[],
                                     optimizations={"a": "b"},
                                     options={"c": "d"})
 

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -89,6 +89,7 @@ class TestBaseWorkflow_init(TestCase):
     def test_must_initialize_variables(self):
         self.work = self.MyWorkflow("source_dir", "artifacts_dir", "scratch_dir", "manifest_path",
                                     runtime="runtime",
+                                    additional_search_paths=[],
                                     optimizations={"a": "b"},
                                     options={"c": "d"})
 
@@ -113,6 +114,7 @@ class TestBaseWorkflow_is_supported(TestCase):
     def setUp(self):
         self.work = self.MyWorkflow("source_dir", "artifacts_dir", "scratch_dir", "manifest_path",
                                     runtime="runtime",
+                                    additional_search_paths=[],
                                     optimizations={"a": "b"},
                                     options={"c": "d"})
 
@@ -150,6 +152,7 @@ class TestBaseWorkflow_run(TestCase):
     def setUp(self):
         self.work = self.MyWorkflow("source_dir", "artifacts_dir", "scratch_dir", "manifest_path",
                                     runtime="runtime",
+                                    additional_search_paths=[],
                                     optimizations={"a": "b"},
                                     options={"c": "d"})
 
@@ -239,6 +242,7 @@ class TestBaseWorkflow_repr(TestCase):
 
         self.work = self.MyWorkflow("source_dir", "artifacts_dir", "scratch_dir", "manifest_path",
                                     runtime="runtime",
+                                    additional_search_paths=[],
                                     optimizations={"a": "b"},
                                     options={"c": "d"})
 


### PR DESCRIPTION
- search for executables on additional paths that are not on `$PATH`
- additional paths take precedence before searching for executables
  on `$PATH`
- rev protocol version to 0.2 with introduction of additional search
  paths.

*Issue #, if available:*

https://github.com/awslabs/aws-lambda-builders/issues/77




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
