### PR TITLE
refactor(go): Updated handler to output_executable_name for go workflows

### DIFF
--- a/aws_lambda_builders/workflows/go_dep/workflow.py
+++ b/aws_lambda_builders/workflows/go_dep/workflow.py
@@ -45,7 +45,7 @@ class GoDepWorkflow(BaseWorkflow):
                                             **kwargs)
 
         options = kwargs["options"] if "options" in kwargs else {}
-        handler = options.get("output_executable_name", None)
+        handler = options.get("artifact_executable_name", None)
 
         if osutils is None:
             osutils = OSUtils()

--- a/aws_lambda_builders/workflows/go_dep/workflow.py
+++ b/aws_lambda_builders/workflows/go_dep/workflow.py
@@ -45,7 +45,7 @@ class GoDepWorkflow(BaseWorkflow):
                                             **kwargs)
 
         options = kwargs["options"] if "options" in kwargs else {}
-        handler = options.get("handler", None)
+        handler = options.get("output_executable_name", None)
 
         if osutils is None:
             osutils = OSUtils()

--- a/aws_lambda_builders/workflows/go_modules/workflow.py
+++ b/aws_lambda_builders/workflows/go_modules/workflow.py
@@ -38,7 +38,7 @@ class GoModulesWorkflow(BaseWorkflow):
             osutils = OSUtils()
 
         options = kwargs.get("options") or {}
-        handler = options.get("output_executable_name", None)
+        handler = options.get("artifact_executable_name", None)
 
         output_path = osutils.joinpath(artifacts_dir, handler)
 

--- a/aws_lambda_builders/workflows/go_modules/workflow.py
+++ b/aws_lambda_builders/workflows/go_modules/workflow.py
@@ -38,7 +38,7 @@ class GoModulesWorkflow(BaseWorkflow):
             osutils = OSUtils()
 
         options = kwargs.get("options") or {}
-        handler = options.get("handler", None)
+        handler = options.get("output_executable_name", None)
 
         output_path = osutils.joinpath(artifacts_dir, handler)
 

--- a/tests/integration/workflows/go_dep/test_go_dep.py
+++ b/tests/integration/workflows/go_dep/test_go_dep.py
@@ -35,7 +35,7 @@ class TestGoDep(TestCase):
         self.builder.build(source_dir, self.artifacts_dir, self.scratch_dir,
                            os.path.join(source_dir, "Gopkg.toml"),
                            runtime=self.runtime,
-                           options={"output_executable_name": "main"})
+                           options={"artifact_executable_name": "main"})
 
         expected_files = {"main"}
         output_files = set(os.listdir(self.artifacts_dir))
@@ -49,7 +49,7 @@ class TestGoDep(TestCase):
             self.builder.build(source_dir, self.artifacts_dir, self.scratch_dir,
                                os.path.join(source_dir, "Gopkg.toml"),
                                runtime=self.runtime,
-                               options={"output_executable_name": "main"})
+                               options={"artifact_executable_name": "main"})
 
         self.assertEquals(
                           "GoDepBuilder:DepEnsure - Exec Failed: could not find project Gopkg.toml," +
@@ -62,7 +62,7 @@ class TestGoDep(TestCase):
         self.builder.build(source_dir, self.artifacts_dir, self.scratch_dir,
                            os.path.join(source_dir, "Gopkg.toml"),
                            runtime=self.runtime,
-                           options={"output_executable_name": "main"})
+                           options={"artifact_executable_name": "main"})
 
         expected_files = {"main"}
         output_files = set(os.listdir(self.artifacts_dir))
@@ -76,7 +76,7 @@ class TestGoDep(TestCase):
             self.builder.build(source_dir, self.artifacts_dir, self.scratch_dir,
                                os.path.join(source_dir, "Gopkg.toml"),
                                runtime=self.runtime,
-                               options={"output_executable_name": "main"})
+                               options={"artifact_executable_name": "main"})
 
         # The full message is super long, so part of it is fine.
         self.assertNotEqual(str(ex.exception).find('unable to deduce repository and source type for'), -1)

--- a/tests/integration/workflows/go_dep/test_go_dep.py
+++ b/tests/integration/workflows/go_dep/test_go_dep.py
@@ -35,7 +35,7 @@ class TestGoDep(TestCase):
         self.builder.build(source_dir, self.artifacts_dir, self.scratch_dir,
                            os.path.join(source_dir, "Gopkg.toml"),
                            runtime=self.runtime,
-                           options={"handler": "main"})
+                           options={"output_executable_name": "main"})
 
         expected_files = {"main"}
         output_files = set(os.listdir(self.artifacts_dir))
@@ -49,7 +49,7 @@ class TestGoDep(TestCase):
             self.builder.build(source_dir, self.artifacts_dir, self.scratch_dir,
                                os.path.join(source_dir, "Gopkg.toml"),
                                runtime=self.runtime,
-                               options={"handler": "main"})
+                               options={"output_executable_name": "main"})
 
         self.assertEquals(
                           "GoDepBuilder:DepEnsure - Exec Failed: could not find project Gopkg.toml," +
@@ -62,7 +62,7 @@ class TestGoDep(TestCase):
         self.builder.build(source_dir, self.artifacts_dir, self.scratch_dir,
                            os.path.join(source_dir, "Gopkg.toml"),
                            runtime=self.runtime,
-                           options={"handler": "main"})
+                           options={"output_executable_name": "main"})
 
         expected_files = {"main"}
         output_files = set(os.listdir(self.artifacts_dir))
@@ -76,7 +76,7 @@ class TestGoDep(TestCase):
             self.builder.build(source_dir, self.artifacts_dir, self.scratch_dir,
                                os.path.join(source_dir, "Gopkg.toml"),
                                runtime=self.runtime,
-                               options={"handler": "main"})
+                               options={"output_executable_name": "main"})
 
         # The full message is super long, so part of it is fine.
         self.assertNotEqual(str(ex.exception).find('unable to deduce repository and source type for'), -1)

--- a/tests/integration/workflows/go_modules/test_go.py
+++ b/tests/integration/workflows/go_modules/test_go.py
@@ -32,7 +32,7 @@ class TestGoWorkflow(TestCase):
         self.builder.build(source_dir, self.artifacts_dir, self.scratch_dir,
                            os.path.join(source_dir, "go.mod"),
                            runtime=self.runtime,
-                           options={"output_executable_name": "no-deps-main"})
+                           options={"artifact_executable_name": "no-deps-main"})
         expected_files = {"no-deps-main"}
         output_files = set(os.listdir(self.artifacts_dir))
         print(output_files)
@@ -43,7 +43,7 @@ class TestGoWorkflow(TestCase):
         self.builder.build(source_dir, self.artifacts_dir, self.scratch_dir,
                            os.path.join(source_dir, "go.mod"),
                            runtime=self.runtime,
-                           options={"output_executable_name": "with-deps-main"})
+                           options={"artifact_executable_name": "with-deps-main"})
         expected_files = {"with-deps-main"}
         output_files = set(os.listdir(self.artifacts_dir))
         self.assertEquals(expected_files, output_files)
@@ -54,6 +54,6 @@ class TestGoWorkflow(TestCase):
             self.builder.build(source_dir, self.artifacts_dir, self.scratch_dir,
                                os.path.join(source_dir, "go.mod"),
                                runtime=self.runtime,
-                               options={"output_executable_name": "failed"})
+                               options={"artifact_executable_name": "failed"})
         self.assertIn("GoModulesBuilder:Build - Builder Failed: ",
                       str(ctx.exception))

--- a/tests/integration/workflows/go_modules/test_go.py
+++ b/tests/integration/workflows/go_modules/test_go.py
@@ -32,7 +32,7 @@ class TestGoWorkflow(TestCase):
         self.builder.build(source_dir, self.artifacts_dir, self.scratch_dir,
                            os.path.join(source_dir, "go.mod"),
                            runtime=self.runtime,
-                           options={"handler": "no-deps-main"})
+                           options={"output_executable_name": "no-deps-main"})
         expected_files = {"no-deps-main"}
         output_files = set(os.listdir(self.artifacts_dir))
         print(output_files)
@@ -43,7 +43,7 @@ class TestGoWorkflow(TestCase):
         self.builder.build(source_dir, self.artifacts_dir, self.scratch_dir,
                            os.path.join(source_dir, "go.mod"),
                            runtime=self.runtime,
-                           options={"handler": "with-deps-main"})
+                           options={"output_executable_name": "with-deps-main"})
         expected_files = {"with-deps-main"}
         output_files = set(os.listdir(self.artifacts_dir))
         self.assertEquals(expected_files, output_files)
@@ -54,6 +54,6 @@ class TestGoWorkflow(TestCase):
             self.builder.build(source_dir, self.artifacts_dir, self.scratch_dir,
                                os.path.join(source_dir, "go.mod"),
                                runtime=self.runtime,
-                               options={"handler": "failed"})
+                               options={"output_executable_name": "failed"})
         self.assertIn("GoModulesBuilder:Build - Builder Failed: ",
                       str(ctx.exception))

--- a/tests/unit/workflows/go_dep/test_workflow.py
+++ b/tests/unit/workflows/go_dep/test_workflow.py
@@ -15,7 +15,7 @@ class TestGoDepWorkflow(TestCase):
                                  "artifacts",
                                  "scratch",
                                  "manifest",
-                                 options={"output_executable_name": "foo"})
+                                 options={"artifact_executable_name": "foo"})
         self.assertEqual(len(workflow.actions), 2)
         self.assertIsInstance(workflow.actions[0], DepEnsureAction)
         self.assertIsInstance(workflow.actions[1], GoBuildAction)

--- a/tests/unit/workflows/go_dep/test_workflow.py
+++ b/tests/unit/workflows/go_dep/test_workflow.py
@@ -11,7 +11,11 @@ class TestGoDepWorkflow(TestCase):
     """
 
     def test_workflow_sets_up_workflow(self):
-        workflow = GoDepWorkflow("source", "artifacts", "scratch", "manifest", options={"handler": "foo"})
+        workflow = GoDepWorkflow("source",
+                                 "artifacts",
+                                 "scratch",
+                                 "manifest",
+                                 options={"output_executable_name": "foo"})
         self.assertEqual(len(workflow.actions), 2)
         self.assertIsInstance(workflow.actions[0], DepEnsureAction)
         self.assertIsInstance(workflow.actions[1], GoBuildAction)

--- a/tests/unit/workflows/go_modules/test_workflow.py
+++ b/tests/unit/workflows/go_modules/test_workflow.py
@@ -14,6 +14,6 @@ class TestGoModulesWorkflow(TestCase):
         workflow = GoModulesWorkflow(
             "source", "artifacts", "scratch_dir", "manifest",
             runtime="go1.x",
-            options={"output_executable_name": "main"})
+            options={"artifact_executable_name": "main"})
         self.assertEqual(len(workflow.actions), 1)
         self.assertIsInstance(workflow.actions[0], GoModulesBuildAction)

--- a/tests/unit/workflows/go_modules/test_workflow.py
+++ b/tests/unit/workflows/go_modules/test_workflow.py
@@ -14,6 +14,6 @@ class TestGoModulesWorkflow(TestCase):
         workflow = GoModulesWorkflow(
             "source", "artifacts", "scratch_dir", "manifest",
             runtime="go1.x",
-            options={"handler": "main"})
+            options={"output_executable_name": "main"})
         self.assertEqual(len(workflow.actions), 1)
         self.assertIsInstance(workflow.actions[0], GoModulesBuildAction)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
