### PR TITLE
[WIP] fix(mod): Allow Go Modules Builder to run in a read only container

### DIFF
--- a/aws_lambda_builders/workflows/go_modules/actions.py
+++ b/aws_lambda_builders/workflows/go_modules/actions.py
@@ -2,6 +2,8 @@
 Action to build a Go project using standard Go tooling
 """
 
+from shutil import copy2
+
 from aws_lambda_builders.actions import BaseAction, Purpose, ActionFailedError
 from .builder import BuilderError
 
@@ -25,3 +27,19 @@ class GoModulesBuildAction(BaseAction):
             )
         except BuilderError as ex:
             raise ActionFailedError(str(ex))
+
+
+class CopyGoSumAction(BaseAction):
+
+    NAME = "Copy go.sum"
+    DESCRIPTION = "Copy go.sum file into artifact dir"
+    PURPOSE = Purpose.COPY_SOURCE
+
+    def __init__(self, source_dir, output_path, osutils):
+        self.source_dir = source_dir
+        self.output_path = output_path
+        self.osutils = osutils
+
+    def execute(self):
+        go_sum_file = self.osutils.joinpath(self.source_dir, "go.sum")
+        copy2(go_sum_file, self.output_path)

--- a/aws_lambda_builders/workflows/go_modules/workflow.py
+++ b/aws_lambda_builders/workflows/go_modules/workflow.py
@@ -3,7 +3,8 @@ Go Modules Workflow
 """
 from aws_lambda_builders.workflow import BaseWorkflow, Capability
 
-from .actions import GoModulesBuildAction
+from aws_lambda_builders.actions import CopySourceAction
+from .actions import GoModulesBuildAction, CopyGoSumAction
 from .builder import GoModulesBuilder
 from .validator import GoRuntimeValidator
 from .utils import OSUtils
@@ -44,7 +45,9 @@ class GoModulesWorkflow(BaseWorkflow):
 
         builder = GoModulesBuilder(osutils, binaries=self.binaries)
         self.actions = [
-            GoModulesBuildAction(source_dir, output_path, builder),
+            CopySourceAction(source_dir, scratch_dir),
+            GoModulesBuildAction(scratch_dir, output_path, builder),
+            CopyGoSumAction(scratch_dir, artifacts_dir, osutils)
         ]
 
     def get_validators(self):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
SAM CLI mounts the source directory as 'ro' within the container. Due to this, Go can't write go.sum file into the directory. To support this use-case, I modified the Go Mod builder to copy the source into the scratch directory and then after building to copy the `go.sum` file to the artifact directory. Go recommends to commit the `go.sum`, so ideally this file is written to where a customer would commit this file.

*Area that need discussion:*
Writing `go.sum` to the artifact directory isn't ideally what we want but is a way to surface this file back to customers. I believe we want this to write back to the source directory to allow customers to commit this file as Go suggests but this because difficult for the container use-case SAM CLI uses (due to the mount being readonly). 
Options: 
1. Try and write this file but gracefully handle the failure of writing. This is to allows `go.sum` to be written to source directory if able to.
2. Never copy `go.sum` and ignore what Go suggests
3. Write the file to the artifact directory and let customers move it to where they want.

I would like to do Option 1, as it follows the Go patterns and what developers expect.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
