### PR TITLE
backcompat: cli

### DIFF
--- a/aws_lambda_builders/__main__.py
+++ b/aws_lambda_builders/__main__.py
@@ -130,7 +130,7 @@ def main():  # pylint: disable=too-many-statements
                       params["artifacts_dir"],
                       params["scratch_dir"],
                       params["manifest_path"],
-                      executable_search_paths=params['executable_search_paths'],
+                      executable_search_paths=params.get('executable_search_paths', None),
                       runtime=params["runtime"],
                       optimizations=params["optimizations"],
                       options=params["options"])

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -57,7 +57,7 @@ class TestCliWithHelloWorkflow(TestCase):
     ])
     def test_run_hello_workflow_with_backcompat(self, flavor, protocol_version):
 
-        request_json = json.dumps({
+        request = {
             "jsonschema": "2.0",
             "id": 1234,
             "method": "LambdaBuilder.build",
@@ -75,11 +75,14 @@ class TestCliWithHelloWorkflow(TestCase):
                 "manifest_path": "/ignored",
                 "runtime": "ignored",
                 "optimizations": {},
-                "options": {},
-                "executable_search_paths": [str(pathlib.Path(sys.executable).parent)]
+                "options": {}
             }
-        })
+        }
 
+        if protocol_version == lambda_builders_protocol_version:
+            request["executable_search_paths"] = [str(pathlib.Path(sys.executable).parent)]
+
+        request_json = json.dumps(request)
 
         env = copy.deepcopy(os.environ)
         env["PYTHONPATH"] = self.python_path


### PR DESCRIPTION
- bugfix: make executable_search_paths computable if not specified and add it as
      `None`.

- explicitly check with a test with older RPC version and removal of
      `executable_search_paths` param.

- This ensures that if the container is upgraded to the latest version of builders, and we build on the container from a older version of SAM CLI, back compat does not break.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
