### PR TITLE
fix: Remove tests from .whl file (bdist_wheel)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     author_email='aws-sam-developers@amazon.com',
     url='https://github.com/awslabs/aws-lambda-builders',
     license='Apache License 2.0',
-    packages=find_packages(exclude=('tests', 'docs')),
+    packages=find_packages(exclude=['tests.*', 'tests']),
     keywords="AWS Lambda Functions Building",
     # Support Python 2.7 and 3.6 or greater
     python_requires=(


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Python wheels, `.whl` files, produced through `python setup.py bdist_wheel` do not read or understand `MANIFEST.in` files. Since we use this file to remove tests modules from the dists, tests end up in the `.whl` files that get uploaded to PyPi. This PR updates the `exclude` parameter in `find_packages` to exclude all `test.*` modules, following [setuptools documentation](https://setuptools.readthedocs.io/en/latest/setuptools.html#using-find-packages).



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
