### PR TITLE
fix: Remove MODULE_NAME command from Maven Workflow

### DIFF
--- a/aws_lambda_builders/workflows/java_maven/DESIGN.md
+++ b/aws_lambda_builders/workflows/java_maven/DESIGN.md
@@ -71,20 +71,16 @@ configured to use a different one than can be found on the PATH.
 
 #### Step 3: Build and package
 
-We leverage Maven to do all the heavy lifting for executing the`mvn package` which
+We leverage Maven to do all the heavy lifting for executing the`mvn clean install` which
 will resolve and download the dependencies and build the project. Built java classes 
 will be located in `target/classes`. Then we use `mvn dependency:copy-dependenceis` to copy
 the dependencies and the dependencies will be located in `target/dependency` under the 
 source directory.
 
 ```bash
-MODULE_NAME=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.artifactId}' exec:exec --non-recursive)
-mvn clean package -pl :MODULE_NAME -am
-mvn dependency:copy-dependencies -DincludeScope=compile -pl :MODULE_NAME
+mvn clean install
+mvn dependency:copy-dependencies -DincludeScope=compile
 ```
-
-Here `MODULE_NAME` is the `artifactId` defined in the pom.xml of the project. Maven
-will build the dependencies of that project in the reactor and then build the project itself.
 
 #### Step 4: Copy to artifact directory
 

--- a/aws_lambda_builders/workflows/java_maven/actions.py
+++ b/aws_lambda_builders/workflows/java_maven/actions.py
@@ -20,17 +20,6 @@ class JavaMavenBaseAction(object):
                  subprocess_maven):
         self.scratch_dir = scratch_dir
         self.subprocess_maven = subprocess_maven
-        self.artifact_id = None
-
-    @property
-    def module_name(self):
-        if self.artifact_id is None:
-            try:
-                self.artifact_id = self.subprocess_maven.retrieve_module_name(self.scratch_dir)
-            except MavenExecutionError as ex:
-                raise ActionFailedError(str(ex))
-
-        return self.artifact_id
 
 
 class JavaMavenBuildAction(JavaMavenBaseAction, BaseAction):
@@ -48,8 +37,7 @@ class JavaMavenBuildAction(JavaMavenBaseAction, BaseAction):
 
     def execute(self):
         try:
-            self.subprocess_maven.build(self.scratch_dir,
-                                        self.module_name)
+            self.subprocess_maven.build(self.scratch_dir)
         except MavenExecutionError as ex:
             raise ActionFailedError(str(ex))
 
@@ -69,8 +57,7 @@ class JavaMavenCopyDependencyAction(JavaMavenBaseAction, BaseAction):
 
     def execute(self):
         try:
-            self.subprocess_maven.copy_dependency(self.scratch_dir,
-                                                  self.module_name)
+            self.subprocess_maven.copy_dependency(self.scratch_dir)
         except MavenExecutionError as ex:
             raise ActionFailedError(str(ex))
 

--- a/aws_lambda_builders/workflows/java_maven/maven.py
+++ b/aws_lambda_builders/workflows/java_maven/maven.py
@@ -25,7 +25,7 @@ class SubprocessMaven(object):
             raise ValueError("Must provide OSUtils")
         self.os_utils = os_utils
 
-    def build(self, scratch_dir, module_name):
+    def build(self, scratch_dir):
         args = ['clean', 'install']
         ret_code, stdout, _ = self._run(args, scratch_dir)
 
@@ -34,7 +34,7 @@ class SubprocessMaven(object):
         if ret_code != 0:
             raise MavenExecutionError(message=stdout.decode('utf8').strip())
 
-    def copy_dependency(self, scratch_dir, module_name):
+    def copy_dependency(self, scratch_dir):
         args = ['dependency:copy-dependencies', '-DincludeScope=compile']
         ret_code, stdout, _ = self._run(args, scratch_dir)
 

--- a/aws_lambda_builders/workflows/java_maven/maven.py
+++ b/aws_lambda_builders/workflows/java_maven/maven.py
@@ -25,16 +25,8 @@ class SubprocessMaven(object):
             raise ValueError("Must provide OSUtils")
         self.os_utils = os_utils
 
-    def retrieve_module_name(self, scratch_dir):
-        args = ['-q', '-Dexec.executable=echo', '-Dexec.args=${project.artifactId}',
-                'exec:exec', '--non-recursive']
-        ret_code, stdout, stderr = self._run(args, scratch_dir)
-        if ret_code != 0:
-            raise MavenExecutionError(message=stderr.decode('utf8').strip())
-        return stdout.decode('utf8').strip()
-
-    def build(self, scratch_dir, module_name):
-        args = ['clean', 'install', '-pl', ':' + module_name, '-am']
+    def build(self, scratch_dir):
+        args = ['clean', 'install']
         ret_code, stdout, stderr = self._run(args, scratch_dir)
 
         LOG.debug("Maven logs: %s", stdout.decode('utf8').strip())
@@ -42,8 +34,8 @@ class SubprocessMaven(object):
         if ret_code != 0:
             raise MavenExecutionError(message=stderr.decode('utf8').strip())
 
-    def copy_dependency(self, scratch_dir, module_name):
-        args = ['dependency:copy-dependencies', '-DincludeScope=compile', '-pl', ':' + module_name]
+    def copy_dependency(self, scratch_dir):
+        args = ['dependency:copy-dependencies', '-DincludeScope=compile']
         ret_code, _, stderr = self._run(args, scratch_dir)
         if ret_code != 0:
             raise MavenExecutionError(message=stderr.decode('utf8').strip())

--- a/tests/unit/workflows/java_maven/test_actions.py
+++ b/tests/unit/workflows/java_maven/test_actions.py
@@ -14,14 +14,12 @@ class TestJavaMavenBuildAction(TestCase):
         self.subprocess_maven = MockSubprocessMaven.return_value
         self.scratch_dir = os.path.join('scratch_dir')
         self.artifacts_dir = os.path.join('artifacts_dir')
-        self.module_name = "module"
 
     def test_calls_maven_build(self):
-        self.subprocess_maven.retrieve_module_name.side_effect = lambda scratch: self.module_name
         action = JavaMavenBuildAction(self.scratch_dir,
                                       self.subprocess_maven)
         action.execute()
-        self.subprocess_maven.build.assert_called_with(self.scratch_dir, self.module_name)
+        self.subprocess_maven.build.assert_called_with(self.scratch_dir)
 
     def test_error_building_project_raises_action_error(self):
         self.subprocess_maven.build.side_effect = MavenExecutionError(message='Build failed!')
@@ -39,14 +37,12 @@ class TestJavaMavenCopyDependencyAction(TestCase):
         self.subprocess_maven = MockSubprocessMaven.return_value
         self.scratch_dir = os.path.join('scratch_dir')
         self.artifacts_dir = os.path.join('artifacts_dir')
-        self.module_name = 'module_name'
 
     def test_calls_maven_copy_dependency(self):
-        self.subprocess_maven.retrieve_module_name.side_effect = lambda scratch: self.module_name
         action = JavaMavenCopyDependencyAction(self.scratch_dir,
                                                self.subprocess_maven)
         action.execute()
-        self.subprocess_maven.copy_dependency.assert_called_with(self.scratch_dir, self.module_name)
+        self.subprocess_maven.copy_dependency.assert_called_with(self.scratch_dir)
 
     def test_error_building_project_raises_action_error(self):
         self.subprocess_maven.copy_dependency.side_effect = MavenExecutionError(message='Build failed!')

--- a/tests/unit/workflows/java_maven/test_maven.py
+++ b/tests/unit/workflows/java_maven/test_maven.py
@@ -43,27 +43,11 @@ class TestSubprocessMaven(TestCase):
             SubprocessMaven(None)
         self.assertEquals(err_assert.exception.args[0], 'Must provide Maven BinaryPath')
 
-    def test_retrieve_module_name(self):
-        maven = SubprocessMaven(maven_binary=self.maven_binary, os_utils=self.os_utils)
-        maven.retrieve_module_name(self.source_dir)
-        self.os_utils.popen.assert_called_with(
-            [self.maven_path, '-q', '-Dexec.executable=echo', '-Dexec.args=${project.artifactId}',
-             'exec:exec', '--non-recursive'],
-            cwd=self.source_dir, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
-
-    def test_retrieve_module_name_raises_exception_if_retcode_not_0(self):
-        self.popen = FakePopen(retcode=1, err=b'Some Error Message')
-        self.os_utils.popen.side_effect = [self.popen]
-        maven = SubprocessMaven(maven_binary=self.maven_binary, os_utils=self.os_utils)
-        with self.assertRaises(MavenExecutionError) as err:
-            maven.retrieve_module_name(self.source_dir)
-        self.assertEquals(err.exception.args[0], 'Maven Failed: Some Error Message')
-
     def test_build_project(self):
         maven = SubprocessMaven(maven_binary=self.maven_binary, os_utils=self.os_utils)
-        maven.build(self.source_dir, self.module_name)
+        maven.build(self.source_dir)
         self.os_utils.popen.assert_called_with(
-            [self.maven_path, 'clean', 'install', '-pl', ':' + self.module_name, '-am'],
+            [self.maven_path, 'clean', 'install'],
             cwd=self.source_dir, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
 
     def test_build_raises_exception_if_retcode_not_0(self):
@@ -71,14 +55,14 @@ class TestSubprocessMaven(TestCase):
         self.os_utils.popen.side_effect = [self.popen]
         maven = SubprocessMaven(maven_binary=self.maven_binary, os_utils=self.os_utils)
         with self.assertRaises(MavenExecutionError) as err:
-            maven.build(self.source_dir, self.module_name)
+            maven.build(self.source_dir)
         self.assertEquals(err.exception.args[0], 'Maven Failed: Some Error Message')
 
     def test_copy_dependency(self):
         maven = SubprocessMaven(maven_binary=self.maven_binary, os_utils=self.os_utils)
-        maven.copy_dependency(self.source_dir, self.module_name)
+        maven.copy_dependency(self.source_dir)
         self.os_utils.popen.assert_called_with(
-            [self.maven_path, 'dependency:copy-dependencies', '-DincludeScope=compile', '-pl', ':' + self.module_name],
+            [self.maven_path, 'dependency:copy-dependencies', '-DincludeScope=compile'],
             cwd=self.source_dir, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
 
     def test_copy_dependency_raises_exception_if_retcode_not_0(self):
@@ -86,5 +70,5 @@ class TestSubprocessMaven(TestCase):
         self.os_utils.popen.side_effect = [self.popen]
         maven = SubprocessMaven(maven_binary=self.maven_binary, os_utils=self.os_utils)
         with self.assertRaises(MavenExecutionError) as err:
-            maven.copy_dependency(self.source_dir, self.module_name)
+            maven.copy_dependency(self.source_dir)
         self.assertEquals(err.exception.args[0], 'Maven Failed: Some Error Message')


### PR DESCRIPTION
On Windows, the echo command is not valid in most cases. The Maven Workflow
was doing some operations that help support the multiple project build
use-case. Given this sometimes fails on Windows, the PR updates the Maven
Worklfow to only install and copy dependencies. This removes the need
to echo and therefore allows Windows Maven builds to succeed without
needing to run within the container.

*Issue #, if available:*
Will solve https://github.com/awslabs/aws-sam-cli/issues/1053, when released within SAM CLI.

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
