### PR TITLE
fix: maven builder logs

### DIFF
--- a/aws_lambda_builders/workflows/java_maven/maven.py
+++ b/aws_lambda_builders/workflows/java_maven/maven.py
@@ -28,25 +28,25 @@ class SubprocessMaven(object):
     def retrieve_module_name(self, scratch_dir):
         args = ['-q', '-Dexec.executable=echo', '-Dexec.args=${project.artifactId}',
                 'exec:exec', '--non-recursive']
-        ret_code, stdout, stderr = self._run(args, scratch_dir)
+        ret_code, stdout, _ = self._run(args, scratch_dir)
         if ret_code != 0:
-            raise MavenExecutionError(message=stderr.decode('utf8').strip())
+            raise MavenExecutionError(message=stdout.decode('utf8').strip())
         return stdout.decode('utf8').strip()
 
     def build(self, scratch_dir, module_name):
         args = ['clean', 'install', '-pl', ':' + module_name, '-am']
-        ret_code, stdout, stderr = self._run(args, scratch_dir)
+        ret_code, stdout, _ = self._run(args, scratch_dir)
 
         LOG.debug("Maven logs: %s", stdout.decode('utf8').strip())
 
         if ret_code != 0:
-            raise MavenExecutionError(message=stderr.decode('utf8').strip())
+            raise MavenExecutionError(message=stdout.decode('utf8').strip())
 
     def copy_dependency(self, scratch_dir, module_name):
         args = ['dependency:copy-dependencies', '-DincludeScope=compile', '-pl', ':' + module_name]
-        ret_code, _, stderr = self._run(args, scratch_dir)
+        ret_code, stdout, _ = self._run(args, scratch_dir)
         if ret_code != 0:
-            raise MavenExecutionError(message=stderr.decode('utf8').strip())
+            raise MavenExecutionError(message=stdout.decode('utf8').strip())
 
     def _run(self, args, cwd=None):
         p = self.os_utils.popen([self.maven_binary.binary_path] + args, cwd=cwd, stdout=subprocess.PIPE,

--- a/tests/unit/workflows/java_maven/test_maven.py
+++ b/tests/unit/workflows/java_maven/test_maven.py
@@ -52,7 +52,7 @@ class TestSubprocessMaven(TestCase):
             cwd=self.source_dir, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
 
     def test_retrieve_module_name_raises_exception_if_retcode_not_0(self):
-        self.popen = FakePopen(retcode=1, err=b'Some Error Message')
+        self.popen = FakePopen(retcode=1, out=b'Some Error Message')
         self.os_utils.popen.side_effect = [self.popen]
         maven = SubprocessMaven(maven_binary=self.maven_binary, os_utils=self.os_utils)
         with self.assertRaises(MavenExecutionError) as err:
@@ -67,7 +67,7 @@ class TestSubprocessMaven(TestCase):
             cwd=self.source_dir, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
 
     def test_build_raises_exception_if_retcode_not_0(self):
-        self.popen = FakePopen(retcode=1, err=b'Some Error Message')
+        self.popen = FakePopen(retcode=1, out=b'Some Error Message')
         self.os_utils.popen.side_effect = [self.popen]
         maven = SubprocessMaven(maven_binary=self.maven_binary, os_utils=self.os_utils)
         with self.assertRaises(MavenExecutionError) as err:
@@ -82,7 +82,7 @@ class TestSubprocessMaven(TestCase):
             cwd=self.source_dir, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
 
     def test_copy_dependency_raises_exception_if_retcode_not_0(self):
-        self.popen = FakePopen(retcode=1, err=b'Some Error Message')
+        self.popen = FakePopen(retcode=1, out=b'Some Error Message')
         self.os_utils.popen.side_effect = [self.popen]
         maven = SubprocessMaven(maven_binary=self.maven_binary, os_utils=self.os_utils)
         with self.assertRaises(MavenExecutionError) as err:


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/awslabs/aws-sam-cli/issues/1056

*Description of changes:*

Look at stdout stream instead of stderr stream to capture maven errors.

Below is a maven template whose pom.xml is looking for a non existent version of junit.

### Before

```
(aws_sam_cli_WS) srirammv@localrainbow:13:40:41:~/sam_init_maven/sam-app$sam build
2019-03-12 13:41:03 Building resource 'HelloWorldFunction'
2019-03-12 13:41:04 Running JavaMavenWorkflow:CopySource
2019-03-12 13:41:04 Running JavaMavenWorkflow:MavenBuild
Build Failed
Error: JavaMavenWorkflow:MavenBuild - Maven Failed:
```

### After 
```
(aws_sam_cli_WS) srirammv@localrainbow:13:40:41:~/sam_init_maven/sam-app$sam build
2019-03-12 13:41:03 Building resource 'HelloWorldFunction'
2019-03-12 13:41:04 Running JavaMavenWorkflow:CopySource
2019-03-12 13:41:04 Running JavaMavenWorkflow:MavenBuild
Build Failed
Error: JavaMavenWorkflow:MavenBuild - Maven Failed: [ERROR] Failed to execute goal on project HelloWorld: Could not resolve dependencies for project helloworld:HelloWorld:jar:1.0: Failure to find junit:junit:jar:1222.12 in https://repo.maven.apache.org/maven2 was cached in the local repository, resolution will not be reattempted until the update interval of central has elapsed or updates are forced -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/DependencyResolutionException
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
