### PR TITLE
fix: match correct java version when only major version provided (#104)

### DIFF
--- a/aws_lambda_builders/workflows/java_maven/maven_validator.py
+++ b/aws_lambda_builders/workflows/java_maven/maven_validator.py
@@ -43,7 +43,7 @@ class MavenValidator(object):
     def _get_major_version(self, maven_path):
         vs = self._get_jvm_string(maven_path)
         if vs:
-            m = re.search(r'Java version:\s+(\d.*)', vs)
+            m = re.search(r'Java version:\s+([\d\.]+)', vs)
             version = m.group(1).split('.')
             # For Java 8 or earlier, version strings begin with 1.{Major Version}
             if version[0] == '1':

--- a/tests/unit/workflows/java_maven/test_maven_validator.py
+++ b/tests/unit/workflows/java_maven/test_maven_validator.py
@@ -39,6 +39,16 @@ class TestMavenBinaryValidator(TestCase):
         self.assertTrue(validator.validate(maven_path=self.maven_path))
         self.assertEqual(validator.validated_binary_path, self.maven_path)
 
+    @parameterized.expand([
+        '12'
+    ])
+    def test_accepts_major_version_only_jvm_mv(self, version):
+        version_string = ('Java version: %s, vendor: Oracle Corporation' % version).encode()
+        self.mock_os_utils.popen.side_effect = [FakePopen(stdout=version_string)]
+        validator = MavenValidator(os_utils=self.mock_os_utils)
+        self.assertTrue(validator.validate(maven_path=self.maven_path))
+        self.assertEqual(validator.validated_binary_path, self.maven_path)
+
     def test_emits_warning_when_jvm_mv_greater_than_8(self):
         version_string = 'Java version: 10.0.1, vendor: Oracle Corporation'.encode()
         self.mock_os_utils.popen.side_effect = [FakePopen(stdout=version_string)]


### PR DESCRIPTION
Use non-greedy match in the regular expression, to handle the case of `mvn -version` provided the major part of java version only.