### PR TITLE
fix: WindowsError keyword is undefined on non-Windows platforms

### DIFF
--- a/aws_lambda_builders/utils.py
+++ b/aws_lambda_builders/utils.py
@@ -36,7 +36,7 @@ def copytree(source, destination, ignore=None):
         try:
             # Let's try to copy the directory metadata from source to destination
             shutil.copystat(source, destination)
-        except WindowsError as ex:  # pylint: disable=undefined-variable
+        except OSError as ex:  # pylint: disable=undefined-variable
             # Can't copy file access times in Windows
             LOG.debug("Unable to copy file access times from %s to %s", source, destination, exc_info=ex)
 

--- a/aws_lambda_builders/utils.py
+++ b/aws_lambda_builders/utils.py
@@ -36,7 +36,7 @@ def copytree(source, destination, ignore=None):
         try:
             # Let's try to copy the directory metadata from source to destination
             shutil.copystat(source, destination)
-        except OSError as ex:  # pylint: disable=undefined-variable
+        except OSError as ex:
             # Can't copy file access times in Windows
             LOG.debug("Unable to copy file access times from %s to %s", source, destination, exc_info=ex)
 


### PR DESCRIPTION
WindowsError is a subclass of `OSError`. It is defined and raised only
in Windows. Hence the exception statement will return a
`WindowsError keyword is undefined` in other platforms.

EDIT: Usually this error is encountered when `CodeUri: /folder/does/not/exist`. The builder tries to copy the files and fails because the path does not exist. On Windows, the exception handler works, but on Mac/Linux Python interpreter does not find the variable `WindowsError` and crashes. So it leads to a vague `WindowsError` on Mac/Linux.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
