### PR TITLE
Ignore .git files

### DIFF
--- a/aws_lambda_builders/workflows/java_maven/workflow.py
+++ b/aws_lambda_builders/workflows/java_maven/workflow.py
@@ -20,7 +20,7 @@ class JavaMavenWorkflow(BaseWorkflow):
                             dependency_manager="maven",
                             application_framework=None)
 
-    EXCLUDED_FILES = (".aws-sam")
+    EXCLUDED_FILES = (".aws-sam", ".git")
 
     def __init__(self,
                  source_dir,

--- a/tests/unit/workflows/java_maven/test_workflow.py
+++ b/tests/unit/workflows/java_maven/test_workflow.py
@@ -48,6 +48,6 @@ class TestJavaMavenWorkflow(TestCase):
 
         self.assertIsInstance(workflow.actions[0], CopySourceAction)
         
-        self.assertEqual(".aws_sam", workflow.actions[0].excludes[0])
+        self.assertEqual(".aws-sam", workflow.actions[0].excludes[0])
         
         self.assertEqual(".git", workflow.actions[0].excludes[0])

--- a/tests/unit/workflows/java_maven/test_workflow.py
+++ b/tests/unit/workflows/java_maven/test_workflow.py
@@ -20,7 +20,7 @@ class TestJavaMavenWorkflow(TestCase):
         self.assertEqual(len(workflow.actions), 4)
 
         self.assertIsInstance(workflow.actions[0], CopySourceAction)
-        
+
         self.assertIsInstance(workflow.actions[1], JavaMavenBuildAction)
 
         self.assertIsInstance(workflow.actions[2], JavaMavenCopyDependencyAction)
@@ -47,7 +47,7 @@ class TestJavaMavenWorkflow(TestCase):
         workflow = JavaMavenWorkflow("source", "artifacts", "scratch_dir", "manifest")
 
         self.assertIsInstance(workflow.actions[0], CopySourceAction)
-        
+
         self.assertEqual(".aws-sam", workflow.actions[0].excludes[0])
-        
+
         self.assertEqual(".git", workflow.actions[0].excludes[0])

--- a/tests/unit/workflows/java_maven/test_workflow.py
+++ b/tests/unit/workflows/java_maven/test_workflow.py
@@ -50,4 +50,4 @@ class TestJavaMavenWorkflow(TestCase):
 
         self.assertEqual(".aws-sam", workflow.actions[0].excludes[0])
 
-        self.assertEqual(".git", workflow.actions[0].excludes[0])
+        self.assertEqual(".git", workflow.actions[0].excludes[1])

--- a/tests/unit/workflows/java_maven/test_workflow.py
+++ b/tests/unit/workflows/java_maven/test_workflow.py
@@ -20,7 +20,7 @@ class TestJavaMavenWorkflow(TestCase):
         self.assertEqual(len(workflow.actions), 4)
 
         self.assertIsInstance(workflow.actions[0], CopySourceAction)
-
+        
         self.assertIsInstance(workflow.actions[1], JavaMavenBuildAction)
 
         self.assertIsInstance(workflow.actions[2], JavaMavenCopyDependencyAction)
@@ -42,3 +42,12 @@ class TestJavaMavenWorkflow(TestCase):
         self.assertEqual(len(validators), 1)
 
         self.assertIsInstance(validators[0], MavenValidator)
+
+    def test_workflow_excluded_files(self):
+        workflow = JavaMavenWorkflow("source", "artifacts", "scratch_dir", "manifest")
+
+        self.assertIsInstance(workflow.actions[0], CopySourceAction)
+        
+        self.assertEqual(".aws_sam", workflow.actions[0].excludes[0])
+        
+        self.assertEqual(".git", workflow.actions[0].excludes[0])


### PR DESCRIPTION
This causes issues on Windows machines due to file handles not being released

*Issue #, if available:*

*Description of changes:*
Added .git to the list of excluded files, similar to the python one which has additional files.
.git causes "WindowsError: [Error 5] Access is denied: c:\\temp\\.git\\objects\\*"

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
