### PR TITLE
Change Go builders to match SAM CLI parameters and behavior

### DIFF
--- a/aws_lambda_builders/workflows/go_dep/workflow.py
+++ b/aws_lambda_builders/workflows/go_dep/workflow.py
@@ -44,15 +44,12 @@ class GoDepWorkflow(BaseWorkflow):
                                             runtime=runtime,
                                             **kwargs)
 
-        options = kwargs["options"] if "options" in kwargs else {}
-        handler = options.get("artifact_executable_name", None)
-
         if osutils is None:
             osutils = OSUtils()
 
         # project base name, where the Gopkg.toml and vendor dir are.
         base_dir = osutils.abspath(osutils.dirname(manifest_path))
-        output_path = osutils.joinpath(osutils.abspath(artifacts_dir), handler)
+        output_path = osutils.joinpath(artifacts_dir, source_dir)
 
         subprocess_dep = SubprocessExec(osutils, "dep")
         subprocess_go = SubprocessExec(osutils, "go")

--- a/aws_lambda_builders/workflows/go_modules/workflow.py
+++ b/aws_lambda_builders/workflows/go_modules/workflow.py
@@ -37,10 +37,7 @@ class GoModulesWorkflow(BaseWorkflow):
         if osutils is None:
             osutils = OSUtils()
 
-        options = kwargs.get("options") or {}
-        handler = options.get("artifact_executable_name", None)
-
-        output_path = osutils.joinpath(artifacts_dir, handler)
+        output_path = osutils.joinpath(artifacts_dir, source_dir)
 
         builder = GoModulesBuilder(osutils, binaries=self.binaries)
         self.actions = [


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

This change is required in order to enforce consistency with the parameters passed by SAM CLI to the other builders. After this PR is merged I will submit a separate PR to [awslabs/aws-sam-cli](https://github.com/awslabs/aws-sam-cli) that enables support for `sam build` for the `go1.x` runtime using either dep or modules.

Both Go builders expect an `options` dictionary to be passed in `**kwargs`; however, SAM CLI does not pass this dictionary. In order to maintain consistent behavior in SAM CLI, this PR updates the artifact name to match the source directory name. This behavior is consistent with the existing Makefile created by `sam init -r go1.x`.

This PR has been tested in Python 2.7, 3.6, and 3.7 with the proposed changes in SAM CLI to enable `sam build`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
