### PR TITLE
fix: change the pip runner string based on a pip version check

### DIFF
--- a/aws_lambda_builders/workflows/python_pip/compat.py
+++ b/aws_lambda_builders/workflows/python_pip/compat.py
@@ -21,6 +21,23 @@ def pip_import_string(python_exe):
         return 'from pip._internal import main'
 
 
+def pip_runner_string(python_exe):
+    os_utils = OSUtils()
+    cmd = [
+        python_exe,
+        "-c",
+        "import pip; assert (int(pip.__version__.split('.')[0]) <= 19 and int(pip.__version__.split('.')[1]) < 3)"
+    ]
+    p = os_utils.popen(cmd, stdout=os_utils.pipe, stderr=os_utils.pipe)
+    p.communicate()
+    # Pip changed main to be a module instead of a function from 19.3
+    # and added a separate main function within the main module.
+    if p.returncode == 0:
+        return 'import sys; %s; sys.exit(main(%s))'
+    else:
+        return 'import sys; %s; sys.exit(main.main(%s))'
+
+
 if os.name == 'nt':
     # windows
     # This is the actual patch used on windows to prevent distutils from

--- a/aws_lambda_builders/workflows/python_pip/compat.py
+++ b/aws_lambda_builders/workflows/python_pip/compat.py
@@ -8,34 +8,25 @@ def pip_import_string(python_exe):
     cmd = [
         python_exe,
         "-c",
-        "import pip; assert int(pip.__version__.split('.')[0]) <= 9"
+        "import pip; print(pip.__version__)"
     ]
-    p = os_utils.popen(cmd,stdout=os_utils.pipe, stderr=os_utils.pipe)
-    p.communicate()
+    p = os_utils.popen(cmd, stdout=os_utils.pipe, stderr=os_utils.pipe)
+    stdout, stderr = p.communicate()
+    pip_version = stdout.decode('utf-8').strip()
+    pip_major_version = int(pip_version.split('.')[0])
+    pip_minor_version = int(pip_version.split('.')[1])
+
     # Pip moved its internals to an _internal module in version 10.
     # In order to be compatible with version 9 which has it at at the
     # top level we need to figure out the correct import path here.
-    if p.returncode == 0:
+    if pip_major_version == 9:
         return 'from pip import main'
+    # Pip changed their import structure again in 19.3
+    # https://github.com/pypa/pip/commit/09fd200
+    elif pip_major_version >= 19 and pip_minor_version >= 3:
+        return 'from pip._internal.main import main'
     else:
         return 'from pip._internal import main'
-
-
-def pip_runner_string(python_exe):
-    os_utils = OSUtils()
-    cmd = [
-        python_exe,
-        "-c",
-        "import pip; assert (int(pip.__version__.split('.')[0]) <= 19 and int(pip.__version__.split('.')[1]) < 3)"
-    ]
-    p = os_utils.popen(cmd, stdout=os_utils.pipe, stderr=os_utils.pipe)
-    p.communicate()
-    # Pip changed main to be a module instead of a function from 19.3
-    # and added a separate main function within the main module.
-    if p.returncode == 0:
-        return 'import sys; %s; sys.exit(main(%s))'
-    else:
-        return 'import sys; %s; sys.exit(main.main(%s))'
 
 
 if os.name == 'nt':

--- a/aws_lambda_builders/workflows/python_pip/packager.py
+++ b/aws_lambda_builders/workflows/python_pip/packager.py
@@ -9,7 +9,7 @@ import logging
 from email.parser import FeedParser
 
 
-from .compat import pip_import_string
+from .compat import pip_import_string, pip_runner_string
 from .compat import pip_no_compile_c_env_vars
 from .compat import pip_no_compile_c_shim
 from .utils import OSUtils
@@ -553,6 +553,7 @@ class SubprocessPip(object):
         self.python_exe = python_exe
         if import_string is None:
             import_string = pip_import_string(python_exe=self.python_exe)
+        self.run_pip_string = pip_runner_string(python_exe=self.python_exe)
         self._import_string = import_string
 
     def main(self, args, env_vars=None, shim=None):
@@ -561,7 +562,7 @@ class SubprocessPip(object):
         if shim is None:
             shim = ''
         run_pip = (
-            'import sys; %s; sys.exit(main(%s))'
+            self.run_pip_string
         ) % (self._import_string, args)
         exec_string = '%s%s' % (shim, run_pip)
         invoke_pip = [self.python_exe, '-c', exec_string]

--- a/aws_lambda_builders/workflows/python_pip/packager.py
+++ b/aws_lambda_builders/workflows/python_pip/packager.py
@@ -9,7 +9,7 @@ import logging
 from email.parser import FeedParser
 
 
-from .compat import pip_import_string, pip_runner_string
+from .compat import pip_import_string
 from .compat import pip_no_compile_c_env_vars
 from .compat import pip_no_compile_c_shim
 from .utils import OSUtils
@@ -553,7 +553,6 @@ class SubprocessPip(object):
         self.python_exe = python_exe
         if import_string is None:
             import_string = pip_import_string(python_exe=self.python_exe)
-        self.run_pip_string = pip_runner_string(python_exe=self.python_exe)
         self._import_string = import_string
 
     def main(self, args, env_vars=None, shim=None):
@@ -562,7 +561,7 @@ class SubprocessPip(object):
         if shim is None:
             shim = ''
         run_pip = (
-            self.run_pip_string
+            'import sys; %s; sys.exit(main(%s))'
         ) % (self._import_string, args)
         exec_string = '%s%s' % (shim, run_pip)
         invoke_pip = [self.python_exe, '-c', exec_string]


### PR DESCRIPTION
- if pip version is less than 19.3, choose to run `pip.main` directly as its a
  function, whereas with pip versions starting with 19.3, execute the
  function `main` inside the pip.main module

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
