### PR TITLE
fix: Do not revert to old broken import for pip 20+.[0-2]

### DIFF
--- a/aws_lambda_builders/workflows/python_pip/compat.py
+++ b/aws_lambda_builders/workflows/python_pip/compat.py
@@ -23,7 +23,7 @@ def pip_import_string(python_exe):
         return 'from pip import main'
     # Pip changed their import structure again in 19.3
     # https://github.com/pypa/pip/commit/09fd200
-    elif pip_major_version >= 19 and pip_minor_version >= 3:
+    elif (pip_major_version, pip_minor_version)  >= (19, 3):
         return 'from pip._internal.main import main'
     else:
         return 'from pip._internal import main'


### PR DESCRIPTION
* Issue: awslabs/aws-sam-cli#1461 (original issue); awslabs/aws-lambda-builders#132 (PR fixing the issue)

*Description of changes:*

This is a followup for awslabs/aws-lambda-builders#132.  The current fix for pip 19.3+ only works for all releases of pip with a minor version >= 3.  It will fail again with pip 20.0.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
