### PR TITLE
fix: better error messages on build failures

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -101,7 +101,7 @@ for:
       - sh: "PATH=/opt/gradle/gradle-5.5/bin:$PATH"
 
       # Install black
-      - sh: "wget -O /tmp/black https://github.com/python/black/releases/download/19.3b0/black"
+      - sh: "wget -O /tmp/black https://github.com/python/black/releases/download/19.10b0/black"
       - sh: "chmod +x /tmp/black"
       - sh: "/tmp/black --version"
 

--- a/.gitignore
+++ b/.gitignore
@@ -257,7 +257,7 @@ wheels/
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt
-
+pip-wheel-metadata/
 # Unit test / coverage reports
 htmlcov/
 .tox/

--- a/aws_lambda_builders/workflow.py
+++ b/aws_lambda_builders/workflow.py
@@ -47,7 +47,10 @@ def sanitize(func):
         for binary, binary_path in binaries_copy.items():
             invalid_paths[binary] = []
             validator = binary_path.validator
-            exec_paths = binary_path.resolver.exec_paths if not binary_path.path_provided else binary_path.binary_path
+            try:
+                exec_paths = binary_path.resolver.exec_paths if not binary_path.path_provided else binary_path.binary_path
+            except ValueError as ex:
+                raise WorkflowFailedError(workflow_name=self.NAME, action_name="Resolver", reason=str(ex))
             for executable_path in exec_paths:
                 try:
                     valid_path = validator.validate(executable_path)
@@ -64,7 +67,7 @@ def sanitize(func):
             validation_failed_binaries = set(self.binaries.keys()).difference(valid_paths.keys())
             message = ""
             for validation_failed_binary in validation_failed_binaries:
-                message = "Binary validation failed for {}, Invalid paths : {}".format(
+                message = "Binary validation failed for {0}, searched for {0} in following locations  : {1} which did not satisfy constraints".format(
                     validation_failed_binary, invalid_paths[validation_failed_binary]
                 )
             raise WorkflowFailedError(workflow_name=self.NAME, action_name="Validation", reason=message)

--- a/aws_lambda_builders/workflow.py
+++ b/aws_lambda_builders/workflow.py
@@ -48,7 +48,9 @@ def sanitize(func):
             invalid_paths[binary] = []
             validator = binary_path.validator
             try:
-                exec_paths = binary_path.resolver.exec_paths if not binary_path.path_provided else binary_path.binary_path
+                exec_paths = (
+                    binary_path.resolver.exec_paths if not binary_path.path_provided else binary_path.binary_path
+                )
             except ValueError as ex:
                 raise WorkflowFailedError(workflow_name=self.NAME, action_name="Resolver", reason=str(ex))
             for executable_path in exec_paths:
@@ -65,12 +67,13 @@ def sanitize(func):
         self.binaries = binaries_copy
         if len(self.binaries) != len(valid_paths):
             validation_failed_binaries = set(self.binaries.keys()).difference(valid_paths.keys())
-            message = ""
+            messages = []
             for validation_failed_binary in validation_failed_binaries:
                 message = "Binary validation failed for {0}, searched for {0} in following locations  : {1} which did not satisfy constraints".format(
                     validation_failed_binary, invalid_paths[validation_failed_binary]
                 )
-            raise WorkflowFailedError(workflow_name=self.NAME, action_name="Validation", reason=message)
+                messages.append(message)
+            raise WorkflowFailedError(workflow_name=self.NAME, action_name="Validation", reason="\n".join(messages))
         func(self, *args, **kwargs)
 
     return wrapper

--- a/aws_lambda_builders/workflow.py
+++ b/aws_lambda_builders/workflow.py
@@ -68,8 +68,8 @@ def sanitize(func):
             validation_failed_binaries = set(self.binaries.keys()).difference(valid_paths.keys())
             messages = []
             for validation_failed_binary in validation_failed_binaries:
-                message = "Binary validation failed for {0}, searched for {0} in following locations  : {1} which did not satisfy constraints".format(
-                    validation_failed_binary, invalid_paths[validation_failed_binary]
+                message = "Binary validation failed for {0}, searched for {0} in following locations  : {1} which did not satisfy constraints for runtime: {2}. Do you have {0} for runtime: {2} on your PATH?".format(
+                    validation_failed_binary, invalid_paths[validation_failed_binary], self.runtime
                 )
                 messages.append(message)
             raise WorkflowFailedError(workflow_name=self.NAME, action_name="Validation", reason="\n".join(messages))

--- a/aws_lambda_builders/workflows/python_pip/actions.py
+++ b/aws_lambda_builders/workflows/python_pip/actions.py
@@ -4,6 +4,7 @@ Action to resolve Python dependencies using PIP
 
 from aws_lambda_builders.actions import BaseAction, Purpose, ActionFailedError
 from aws_lambda_builders.workflows.python_pip.utils import OSUtils
+from .exceptions import MissingPipError
 from .packager import PythonPipDependencyBuilder, PackagerError, DependencyBuilder, SubprocessPip, PipRunner
 
 
@@ -24,7 +25,10 @@ class PythonPipBuildAction(BaseAction):
     def execute(self):
         os_utils = OSUtils()
         python_path = self.binaries[self.LANGUAGE].binary_path
-        pip = SubprocessPip(osutils=os_utils, python_exe=python_path)
+        try:
+            pip = SubprocessPip(osutils=os_utils, python_exe=python_path)
+        except MissingPipError as ex:
+            raise ActionFailedError(str(ex))
         pip_runner = PipRunner(python_exe=python_path, pip=pip)
         dependency_builder = DependencyBuilder(osutils=os_utils, pip_runner=pip_runner, runtime=self.runtime)
 

--- a/aws_lambda_builders/workflows/python_pip/compat.py
+++ b/aws_lambda_builders/workflows/python_pip/compat.py
@@ -1,10 +1,16 @@
 import os
 
+from aws_lambda_builders.workflows.python_pip.exceptions import MissingPipError
 from aws_lambda_builders.workflows.python_pip.utils import OSUtils
 
 
 def pip_import_string(python_exe):
     os_utils = OSUtils()
+    cmd = [python_exe, "-c", "import pip;"]
+    p = os_utils.popen(cmd, stdout=os_utils.pipe, stderr=os_utils.pipe)
+    _, _ = p.communicate()
+    if not p.returncode == 0:
+        raise MissingPipError(python_path=python_exe)
     cmd = [python_exe, "-c", "import pip; print(pip.__version__)"]
     p = os_utils.popen(cmd, stdout=os_utils.pipe, stderr=os_utils.pipe)
     stdout, stderr = p.communicate()

--- a/aws_lambda_builders/workflows/python_pip/compat.py
+++ b/aws_lambda_builders/workflows/python_pip/compat.py
@@ -6,14 +6,11 @@ from aws_lambda_builders.workflows.python_pip.utils import OSUtils
 
 def pip_import_string(python_exe):
     os_utils = OSUtils()
-    cmd = [python_exe, "-c", "import pip;"]
-    p = os_utils.popen(cmd, stdout=os_utils.pipe, stderr=os_utils.pipe)
-    _, _ = p.communicate()
-    if not p.returncode == 0:
-        raise MissingPipError(python_path=python_exe)
     cmd = [python_exe, "-c", "import pip; print(pip.__version__)"]
     p = os_utils.popen(cmd, stdout=os_utils.pipe, stderr=os_utils.pipe)
     stdout, stderr = p.communicate()
+    if not p.returncode == 0:
+        raise MissingPipError(python_path=python_exe)
     pip_version = stdout.decode("utf-8").strip()
     pip_major_version = int(pip_version.split(".")[0])
     pip_minor_version = int(pip_version.split(".")[1])

--- a/aws_lambda_builders/workflows/python_pip/exceptions.py
+++ b/aws_lambda_builders/workflows/python_pip/exceptions.py
@@ -1,3 +1,6 @@
+"""
+Python pip specific workflow exceptions.
+"""
 from aws_lambda_builders.exceptions import LambdaBuilderError
 
 

--- a/aws_lambda_builders/workflows/python_pip/exceptions.py
+++ b/aws_lambda_builders/workflows/python_pip/exceptions.py
@@ -1,0 +1,5 @@
+from aws_lambda_builders.exceptions import LambdaBuilderError
+
+
+class MissingPipError(LambdaBuilderError):
+    MESSAGE = "pip executable not found in your python environment at {python_path}"

--- a/tests/functional/testdata/cwd.py
+++ b/tests/functional/testdata/cwd.py
@@ -1,3 +1,3 @@
 import os
 
-print (os.getcwd())
+print(os.getcwd())

--- a/tests/integration/workflows/go_modules/test_go.py
+++ b/tests/integration/workflows/go_modules/test_go.py
@@ -37,7 +37,7 @@ class TestGoWorkflow(TestCase):
         )
         expected_files = {"no-deps-main"}
         output_files = set(os.listdir(self.artifacts_dir))
-        print (output_files)
+        print(output_files)
         self.assertEquals(expected_files, output_files)
 
     def test_builds_project_with_dependencies(self):

--- a/tests/integration/workflows/python_pip/test_python_pip.py
+++ b/tests/integration/workflows/python_pip/test_python_pip.py
@@ -64,7 +64,7 @@ class TestPythonPipWorkflow(TestCase):
                 runtime=self.runtime_mismatch[self.runtime],
             )
         except WorkflowFailedError as ex:
-            self.assertIn("Binary validation failed!", str(ex))
+            self.assertIn("Binary validation failed", str(ex))
 
     def test_runtime_validate_python_project_fail_open_unsupported_runtime(self):
         with self.assertRaises(WorkflowFailedError):

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -1,9 +1,8 @@
 import os
 import sys
 from unittest import TestCase
-from unittest.mock import MagicMock
 
-from mock import Mock, call
+from mock import Mock, MagicMock, call
 
 try:
     import pathlib

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -229,9 +229,11 @@ class TestBaseWorkflow_run(TestCase):
         action_mock = Mock()
         validator_mock = Mock()
         validator_mock.validate = Mock()
-        validator_mock.validate = MagicMock(side_effect=MisMatchRuntimeError(language="test", required_runtime="test1", runtime_path="/usr/bin/binary"))
+        validator_mock.validate = MagicMock(
+            side_effect=MisMatchRuntimeError(language="test", required_runtime="test1", runtime_path="/usr/bin/binary")
+        )
         resolver_mock = Mock()
-        resolver_mock.exec_paths = ['/usr/bin/binary']
+        resolver_mock.exec_paths = ["/usr/bin/binary"]
         binaries_mock = Mock()
         binaries_mock.return_value = []
 

--- a/tests/unit/workflows/python_pip/test_packager.py
+++ b/tests/unit/workflows/python_pip/test_packager.py
@@ -20,7 +20,7 @@ from aws_lambda_builders.workflows.python_pip.packager import PackageDownloadErr
 
 from aws_lambda_builders.workflows.python_pip import packager
 
-print (packager)
+print(packager)
 
 FakePipCall = namedtuple("FakePipEntry", ["args", "env_vars", "shim"])
 


### PR DESCRIPTION
Why is this change necessary?

* Generic "Binary Validation Failed" does not add enough value

How does it address the issue?

* Showcases which binary has failed and shows which paths were looked
at.

What side effects does this change have?

* None.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
