### PR TITLE
fix: Regex for getting aws_lambda_builders version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def read_requirements(req="base.txt"):
 
 def read_version():
     content = read(os.path.join(os.path.dirname(__file__), "aws_lambda_builders", "__init__.py"))
-    return re.search(r"__version__ = \"([^']+)\"", content).group(1)
+    return re.search(r"__version__ = \"([^'\"]+)", content).group(1)
 
 
 cmd_name = "lambda-builders"


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
I noticed that the version of Lambda Builders was the whole file. This gets tracked back to when we added

```
# new regex
>>> re.search(r"__version__ = \"([^'\"]+)", content).group(1)
'0.6.0'

# old regex
>>> re.search(r"__version__ = \"([^']+)\"", content).group(1)
'0.6.0"\nRPC_PROTOCOL_VERSION = "0.3'
```

This did not happen before because the `__version__` was a string in single quotes and `RPC_PROTOCOL_VERSION` was double quotes. https://github.com/awslabs/aws-lambda-builders/commit/557214b5afff48d93e761d7286dd12c89ec8dc82#diff-eeb75f3f96c23565c44aae048349b2a3 Our regex at that time, assumed only version was the only thing in single quotes in the file (`aws_lambda_builders/__init__.py`). When we updated to standardize strings to be all double quotes with black, I update this regex assuming the regex was already taking into account many things in the file. This PR fixes that assumption so that the version is only the `__version__` value.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
