### PR TITLE
fix: npm output handling

### DIFF
--- a/aws_lambda_builders/workflows/nodejs_npm/actions.py
+++ b/aws_lambda_builders/workflows/nodejs_npm/actions.py
@@ -56,7 +56,7 @@ class NodejsNpmPackAction(BaseAction):
 
             LOG.debug("NODEJS packaging %s to %s", package_path, self.scratch_dir)
 
-            tarfile_name = self.subprocess_npm.run(["pack", "-q", package_path], cwd=self.scratch_dir)
+            tarfile_name = self.subprocess_npm.run(['pack', '-q', package_path], cwd=self.scratch_dir).splitlines()[-1]
 
             LOG.debug("NODEJS packed to %s", tarfile_name)
 

--- a/aws_lambda_builders/workflows/nodejs_npm/actions.py
+++ b/aws_lambda_builders/workflows/nodejs_npm/actions.py
@@ -56,7 +56,7 @@ class NodejsNpmPackAction(BaseAction):
 
             LOG.debug("NODEJS packaging %s to %s", package_path, self.scratch_dir)
 
-            tarfile_name = self.subprocess_npm.run(['pack', '-q', package_path], cwd=self.scratch_dir).splitlines()[-1]
+            tarfile_name = self.subprocess_npm.run(["pack", "-q", package_path], cwd=self.scratch_dir).splitlines()[-1]
 
             LOG.debug("NODEJS packed to %s", tarfile_name)
 


### PR DESCRIPTION
Hi,

*Issue*
If `prepack` script is defined `npm` seems to output more than expected in original code.

*Description of changes:*
`npm pack` outputs filename as last line of stdout, while in code the whole its output was assigned to `tarfile_name` var. This fix makes it right.


Thanks,
Alex



p.s. By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
