### PR TITLE
Add the --unsafe-perm flag to to npm install

### DIFF
--- a/aws_lambda_builders/workflows/nodejs_npm/actions.py
+++ b/aws_lambda_builders/workflows/nodejs_npm/actions.py
@@ -105,7 +105,7 @@ class NodejsNpmInstallAction(BaseAction):
             LOG.debug("NODEJS installing in: %s", self.artifacts_dir)
 
             self.subprocess_npm.run(
-                ["install", "-q", "--no-audit", "--no-save", "--production" "--unsafe-perm"], cwd=self.artifacts_dir
+                ["install", "-q", "--no-audit", "--no-save", "--production", "--unsafe-perm"], cwd=self.artifacts_dir
             )
 
         except NpmExecutionError as ex:

--- a/aws_lambda_builders/workflows/nodejs_npm/actions.py
+++ b/aws_lambda_builders/workflows/nodejs_npm/actions.py
@@ -105,7 +105,7 @@ class NodejsNpmInstallAction(BaseAction):
             LOG.debug("NODEJS installing in: %s", self.artifacts_dir)
 
             self.subprocess_npm.run(
-                ["install", "-q", "--no-audit", "--no-save", "--production"], cwd=self.artifacts_dir
+                ["install", "-q", "--no-audit", "--no-save", "--production" "--unsafe-perm"], cwd=self.artifacts_dir
             )
 
         except NpmExecutionError as ex:

--- a/tests/unit/workflows/nodejs_npm/test_actions.py
+++ b/tests/unit/workflows/nodejs_npm/test_actions.py
@@ -61,7 +61,7 @@ class TestNodejsNpmInstallAction(TestCase):
 
         action.execute()
 
-        expected_args = ["install", "-q", "--no-audit", "--no-save", "--production"]
+        expected_args = ["install", "-q", "--no-audit", "--no-save", "--production", "--production--unsafe-perm"]
 
         subprocess_npm.run.assert_called_with(expected_args, cwd="artifacts")
 


### PR DESCRIPTION
*Description of changes:*

NPM will not execute any script hooks if it is running as root, which is common in docker environments (i.e `sam build --use-container`). The `postinstall` script hook is commonly used by many libraries (especially ones involving native bindings), and it is highly confusing as to why hooks are not run when executing `sam build --use-container` versus `sam build` locally. 

Adding ﻿--unsafe-perm enables this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
