### PR TITLE
--ignore-failed-sources flag fix sam build error

### DIFF
--- a/aws_lambda_builders/workflows/dotnet_clipackage/actions.py
+++ b/aws_lambda_builders/workflows/dotnet_clipackage/actions.py
@@ -30,11 +30,11 @@ class GlobalToolInstallAction(BaseAction):
     def execute(self):
         try:
             LOG.debug("Installing Amazon.Lambda.Tools Global Tool")
-            self.subprocess_dotnet.run(["tool", "install", "-g", "Amazon.Lambda.Tools"])
+            self.subprocess_dotnet.run(["tool", "install", "-g", "Amazon.Lambda.Tools", "--ignore-failed-sources"])
         except DotnetCLIExecutionError as ex:
             LOG.debug("Error installing probably due to already installed. Attempt to update to latest version.")
             try:
-                self.subprocess_dotnet.run(["tool", "update", "-g", "Amazon.Lambda.Tools"])
+                self.subprocess_dotnet.run(["tool", "update", "-g", "Amazon.Lambda.Tools", "--ignore-failed-sources"])
             except DotnetCLIExecutionError as ex:
                 raise ActionFailedError("Error configuring the Amazon.Lambda.Tools .NET Core Global Tool: " + str(ex))
 

--- a/tests/unit/workflows/dotnet_clipackage/test_actions.py
+++ b/tests/unit/workflows/dotnet_clipackage/test_actions.py
@@ -19,14 +19,14 @@ class TestGlobalToolInstallAction(TestCase):
     def test_global_tool_install(self):
         action = GlobalToolInstallAction(self.subprocess_dotnet)
         action.execute()
-        self.subprocess_dotnet.run.assert_called_once_with(["tool", "install", "-g", "Amazon.Lambda.Tools"])
+        self.subprocess_dotnet.run.assert_called_once_with(["tool", "install", "-g", "Amazon.Lambda.Tools", "--ignore-failed-sources"])
 
     def test_global_tool_update(self):
         self.subprocess_dotnet.run.side_effect = [DotnetCLIExecutionError(message="Already Installed"), None]
         action = GlobalToolInstallAction(self.subprocess_dotnet)
         action.execute()
-        self.subprocess_dotnet.run.assert_any_call(["tool", "install", "-g", "Amazon.Lambda.Tools"])
-        self.subprocess_dotnet.run.assert_any_call(["tool", "update", "-g", "Amazon.Lambda.Tools"])
+        self.subprocess_dotnet.run.assert_any_call(["tool", "install", "-g", "Amazon.Lambda.Tools", "--ignore-failed-sources"])
+        self.subprocess_dotnet.run.assert_any_call(["tool", "update", "-g", "Amazon.Lambda.Tools", "--ignore-failed-sources"])
 
     def test_global_tool_update_failed(self):
         self.subprocess_dotnet.run.side_effect = [

--- a/tests/unit/workflows/dotnet_clipackage/test_actions.py
+++ b/tests/unit/workflows/dotnet_clipackage/test_actions.py
@@ -19,14 +19,20 @@ class TestGlobalToolInstallAction(TestCase):
     def test_global_tool_install(self):
         action = GlobalToolInstallAction(self.subprocess_dotnet)
         action.execute()
-        self.subprocess_dotnet.run.assert_called_once_with(["tool", "install", "-g", "Amazon.Lambda.Tools", "--ignore-failed-sources"])
+        self.subprocess_dotnet.run.assert_called_once_with(
+            ["tool", "install", "-g", "Amazon.Lambda.Tools", "--ignore-failed-sources"]
+        )
 
     def test_global_tool_update(self):
         self.subprocess_dotnet.run.side_effect = [DotnetCLIExecutionError(message="Already Installed"), None]
         action = GlobalToolInstallAction(self.subprocess_dotnet)
         action.execute()
-        self.subprocess_dotnet.run.assert_any_call(["tool", "install", "-g", "Amazon.Lambda.Tools", "--ignore-failed-sources"])
-        self.subprocess_dotnet.run.assert_any_call(["tool", "update", "-g", "Amazon.Lambda.Tools", "--ignore-failed-sources"])
+        self.subprocess_dotnet.run.assert_any_call(
+            ["tool", "install", "-g", "Amazon.Lambda.Tools", "--ignore-failed-sources"]
+        )
+        self.subprocess_dotnet.run.assert_any_call(
+            ["tool", "update", "-g", "Amazon.Lambda.Tools", "--ignore-failed-sources"]
+        )
 
     def test_global_tool_update_failed(self):
         self.subprocess_dotnet.run.side_effect = [


### PR DESCRIPTION
Please refer to this issue I created: https://github.com/awslabs/aws-sam-cli/issues/1970

Summary: when users have private feeds configured on their machines, the sam build command will fail because the dotnet cli tries to reference private feeds configured in the machine's global Nuget.Config

Adding the --ignore-failed-sources flag (e.g. dotnet tool install "Amazaon.Lambda.Tools" -g --ignore-failed-sources) fixes the issue.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
