### PR TITLE
Changed dotnet Encoding to System Locale Dependent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,6 +187,7 @@ typings/
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
 # User-specific stuff:
+.vscode
 
 # Sensitive or high-churn files:
 

--- a/aws_lambda_builders/workflows/dotnet_clipackage/dotnetcli.py
+++ b/aws_lambda_builders/workflows/dotnet_clipackage/dotnetcli.py
@@ -51,6 +51,8 @@ class SubprocessDotnetCLI(object):
         LOG.debug("executing dotnet: %s", invoke_dotnet)
 
         # DotNet output is in system locale dependent encoding
+        # https://docs.microsoft.com/en-us/dotnet/api/system.console.outputencoding?view=netcore-3.1#remarks
+        # "The default code page that the console uses is determined by the system locale."
         encoding = locale.getpreferredencoding()
         p = self.os_utils.popen(invoke_dotnet, stdout=self.os_utils.pipe, stderr=self.os_utils.pipe, cwd=cwd)
 

--- a/aws_lambda_builders/workflows/dotnet_clipackage/dotnetcli.py
+++ b/aws_lambda_builders/workflows/dotnet_clipackage/dotnetcli.py
@@ -49,14 +49,22 @@ class SubprocessDotnetCLI(object):
 
         LOG.debug("executing dotnet: %s", invoke_dotnet)
 
-        p = self.os_utils.popen(invoke_dotnet, stdout=self.os_utils.pipe, stderr=self.os_utils.pipe, cwd=cwd)
+        #TODO Support for other OS
+        encoding, encoding_err = self.os_utils.popen(["powershell.exe",
+                    "[system.console]::OutputEncoding.CodePage"],
+                    stdout=self.os_utils.pipe, stderr=self.os_utils.pipe, encoding="ascii").communicate()
+
+        encoding = encoding.strip()
+        LOG.info("Encoding: %s" % encoding)
+        
+        p = self.os_utils.popen(invoke_dotnet, stdout=self.os_utils.pipe, stderr=self.os_utils.pipe, cwd=cwd, encoding=encoding)
 
         out, err = p.communicate()
 
         # The package command contains lots of useful information on how the package was created and
         # information when the package command was not successful. For that reason the output is
         # always written to the output to help developers diagnose issues.
-        LOG.info(out.decode("utf8").strip())
+        LOG.info(out.strip())
 
         if p.returncode != 0:
-            raise DotnetCLIExecutionError(message=err.decode("utf8").strip())
+            raise DotnetCLIExecutionError(message=err.strip())

--- a/aws_lambda_builders/workflows/dotnet_clipackage/dotnetcli.py
+++ b/aws_lambda_builders/workflows/dotnet_clipackage/dotnetcli.py
@@ -52,16 +52,14 @@ class SubprocessDotnetCLI(object):
 
         # DotNet output is in system locale dependent encoding
         encoding = locale.getpreferredencoding()
-        p = self.os_utils.popen(
-            invoke_dotnet, stdout=self.os_utils.pipe, stderr=self.os_utils.pipe, cwd=cwd, encoding=encoding
-        )
+        p = self.os_utils.popen(invoke_dotnet, stdout=self.os_utils.pipe, stderr=self.os_utils.pipe, cwd=cwd)
 
         out, err = p.communicate()
 
         # The package command contains lots of useful information on how the package was created and
         # information when the package command was not successful. For that reason the output is
         # always written to the output to help developers diagnose issues.
-        LOG.info(out.strip())
+        LOG.info(out.decode(encoding).strip())
 
         if p.returncode != 0:
-            raise DotnetCLIExecutionError(message=err.strip())
+            raise DotnetCLIExecutionError(message=err.decode(encoding).strip())

--- a/aws_lambda_builders/workflows/dotnet_clipackage/dotnetcli.py
+++ b/aws_lambda_builders/workflows/dotnet_clipackage/dotnetcli.py
@@ -4,6 +4,7 @@ Wrapper around calls to dotent CLI through a subprocess.
 
 import sys
 import logging
+import locale
 
 from .utils import OSUtils
 
@@ -49,14 +50,8 @@ class SubprocessDotnetCLI(object):
 
         LOG.debug("executing dotnet: %s", invoke_dotnet)
 
-        #TODO Support for other OS
-        encoding, encoding_err = self.os_utils.popen(["powershell.exe",
-                    "[system.console]::OutputEncoding.CodePage"],
-                    stdout=self.os_utils.pipe, stderr=self.os_utils.pipe, encoding="ascii").communicate()
-
-        encoding = encoding.strip()
-        LOG.info("Encoding: %s" % encoding)
-        
+        # DotNet output is in system locale dependent encoding
+        encoding = locale.getpreferredencoding()
         p = self.os_utils.popen(invoke_dotnet, stdout=self.os_utils.pipe, stderr=self.os_utils.pipe, cwd=cwd, encoding=encoding)
 
         out, err = p.communicate()

--- a/aws_lambda_builders/workflows/dotnet_clipackage/dotnetcli.py
+++ b/aws_lambda_builders/workflows/dotnet_clipackage/dotnetcli.py
@@ -52,7 +52,9 @@ class SubprocessDotnetCLI(object):
 
         # DotNet output is in system locale dependent encoding
         encoding = locale.getpreferredencoding()
-        p = self.os_utils.popen(invoke_dotnet, stdout=self.os_utils.pipe, stderr=self.os_utils.pipe, cwd=cwd, encoding=encoding)
+        p = self.os_utils.popen(
+            invoke_dotnet, stdout=self.os_utils.pipe, stderr=self.os_utils.pipe, cwd=cwd, encoding=encoding
+        )
 
         out, err = p.communicate()
 

--- a/aws_lambda_builders/workflows/dotnet_clipackage/utils.py
+++ b/aws_lambda_builders/workflows/dotnet_clipackage/utils.py
@@ -15,8 +15,8 @@ class OSUtils(object):
     Convenience wrapper around common system functions
     """
 
-    def popen(self, command, stdout=None, stderr=None, env=None, cwd=None):
-        p = subprocess.Popen(command, stdout=stdout, stderr=stderr, env=env, cwd=cwd)
+    def popen(self, command, stdout=None, stderr=None, env=None, cwd=None, encoding=None):
+        p = subprocess.Popen(command, stdout=stdout, stderr=stderr, env=env, cwd=cwd, encoding=encoding)
         return p
 
     def is_windows(self):

--- a/aws_lambda_builders/workflows/dotnet_clipackage/utils.py
+++ b/aws_lambda_builders/workflows/dotnet_clipackage/utils.py
@@ -15,8 +15,8 @@ class OSUtils(object):
     Convenience wrapper around common system functions
     """
 
-    def popen(self, command, stdout=None, stderr=None, env=None, cwd=None, encoding=None):
-        p = subprocess.Popen(command, stdout=stdout, stderr=stderr, env=env, cwd=cwd, encoding=encoding)
+    def popen(self, command, stdout=None, stderr=None, env=None, cwd=None):
+        p = subprocess.Popen(command, stdout=stdout, stderr=stderr, env=env, cwd=cwd)
         return p
 
     def is_windows(self):

--- a/tests/integration/workflows/custom_make/test_custom_make.py
+++ b/tests/integration/workflows/custom_make/test_custom_make.py
@@ -44,7 +44,7 @@ class TestCustomMakeWorkflow(TestCase):
             "chardet",
             "urllib3",
             "idna",
-            "urllib3-1.25.9.dist-info",
+            "urllib3-1.25.10.dist-info",
             "chardet-3.0.4.dist-info",
             "certifi-2020.4.5.2.dist-info",
             "certifi",


### PR DESCRIPTION
*Issues
https://github.com/awslabs/aws-lambda-builders/issues/184
https://github.com/awslabs/aws-sam-cli/issues/2031
https://github.com/awslabs/aws-sam-cli/issues/1164
https://github.com/aws/aws-toolkit-vscode/issues/1144

*Description of changes:*
aws dotnet extension output encoding is Console.OutputEncoding which is not UTF-8 in Windows(with utf8 beta option turned off).
Changed decoding to match the extension's system locale dependent encoding.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
