### PR TITLE
fix(ruby): use stdout stream to raise exceptions from bundler

### DIFF
--- a/aws_lambda_builders/workflows/ruby_bundler/bundler.py
+++ b/aws_lambda_builders/workflows/ruby_bundler/bundler.py
@@ -48,9 +48,10 @@ class SubprocessBundler(object):
 
         p = self.osutils.popen(invoke_bundler, stdout=self.osutils.pipe, stderr=self.osutils.pipe, cwd=cwd)
 
-        out, err = p.communicate()
+        out, _ = p.communicate()
 
         if p.returncode != 0:
-            raise BundlerExecutionError(message=err.decode("utf8").strip())
+            # Bundler has relevant information in stdout, not stderr.
+            raise BundlerExecutionError(message=out.decode("utf8").strip())
 
         return out.decode("utf8").strip()

--- a/tests/unit/workflows/ruby_bundler/test_bundler.py
+++ b/tests/unit/workflows/ruby_bundler/test_bundler.py
@@ -58,7 +58,7 @@ class TestSubprocessBundler(TestCase):
 
     def test_raises_BundlerExecutionError_with_err_text_if_retcode_is_not_0(self):
         self.popen.returncode = 1
-        self.popen.err = b"some error text\n\n"
+        self.popen.out = b"some error text\n\n"
         with self.assertRaises(BundlerExecutionError) as raised:
             self.under_test.run(["install", "--without", "development", "test"])
         self.assertEqual(raised.exception.args[0], "Bundler Failed: some error text")


### PR DESCRIPTION
- relevant error information is in stdout instead of stderr for bundler.

Issue: https://github.com/awslabs/aws-sam-cli/issues/939


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
